### PR TITLE
Snapshot refactoring

### DIFF
--- a/project-minimization-core/src/main/kotlin/org/plan/research/minimization/core/algorithm/dd/hierarchical/HierarchicalDD.kt
+++ b/project-minimization-core/src/main/kotlin/org/plan/research/minimization/core/algorithm/dd/hierarchical/HierarchicalDD.kt
@@ -1,18 +1,18 @@
 package org.plan.research.minimization.core.algorithm.dd.hierarchical
 
+import arrow.core.getOrElse
 import kotlinx.coroutines.yield
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithm
 import org.plan.research.minimization.core.model.DDItem
 import org.plan.research.minimization.core.model.DDContext
 
 class HierarchicalDD(private val baseDDAlgorithm: DDAlgorithm) {
-    suspend fun <C : DDContext, T : DDItem> minimize(generator: HierarchicalDDGenerator<C, T>): C {
-        var level = generator.generateFirstLevel()
+    suspend fun <C : DDContext, T : DDItem> minimize(context: C, generator: HierarchicalDDGenerator<C, T>): C {
+        var level = generator.generateFirstLevel(context).getOrElse { return context }
         while (true) {
             yield()
             val minimizedLevel = baseDDAlgorithm.minimize(level.context, level.items, level.propertyTester)
-            level = generator.generateNextLevel(minimizedLevel) ?: break
+            level = generator.generateNextLevel(minimizedLevel).getOrElse { return minimizedLevel.context }
         }
-        return level.context
     }
 }

--- a/project-minimization-core/src/main/kotlin/org/plan/research/minimization/core/algorithm/dd/hierarchical/HierarchicalDDGenerator.kt
+++ b/project-minimization-core/src/main/kotlin/org/plan/research/minimization/core/algorithm/dd/hierarchical/HierarchicalDDGenerator.kt
@@ -1,5 +1,6 @@
 package org.plan.research.minimization.core.algorithm.dd.hierarchical
 
+import arrow.core.Option
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithmResult
 import org.plan.research.minimization.core.model.DDItem
 import org.plan.research.minimization.core.model.DDContext
@@ -11,6 +12,6 @@ data class HDDLevel<C : DDContext, T : DDItem>(
 )
 
 interface HierarchicalDDGenerator<C : DDContext, T : DDItem> {
-    suspend fun generateFirstLevel(): HDDLevel<C, T>
-    suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<C, T>): HDDLevel<C, T>?
+    suspend fun generateFirstLevel(context: C): Option<HDDLevel<C, T>>
+    suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<C, T>): Option<HDDLevel<C, T>>
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
@@ -10,6 +10,8 @@ import org.plan.research.minimization.core.algorithm.dd.impl.ProbabilisticDD
 import org.plan.research.minimization.plugin.execution.DumbCompiler
 import org.plan.research.minimization.plugin.hierarchy.FileTreeHierarchyGenerator
 import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
+import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.model.ProjectFileDDItem
 import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer
 import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.state.CompilationStrategy
@@ -60,3 +62,6 @@ fun List<VirtualFile>.getAllParents(root: VirtualFile): List<VirtualFile> = buil
     }
     this@getAllParents.forEach(::traverseParents)
 }.toList()
+
+fun List<ProjectFileDDItem>.toVirtualFiles(context: IJDDContext): List<VirtualFile> =
+    mapNotNull { it.getVirtualFile(context) }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
@@ -9,6 +9,9 @@ import org.plan.research.minimization.core.algorithm.dd.impl.ProbabilisticDD
 import org.plan.research.minimization.plugin.execution.DumbCompiler
 import org.plan.research.minimization.plugin.hierarchy.FileTreeHierarchyGenerator
 import org.plan.research.minimization.plugin.model.*
+import org.plan.research.minimization.plugin.model.state.CompilationStrategy
+import org.plan.research.minimization.plugin.model.state.DDStrategy
+import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
 
 
 fun HierarchyCollectionStrategy.getHierarchyCollectionStrategy(): ProjectHierarchyProducer<*> =

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/Util.kt
@@ -1,5 +1,6 @@
 package org.plan.research.minimization.plugin
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -8,11 +9,20 @@ import org.plan.research.minimization.core.algorithm.dd.impl.DDMin
 import org.plan.research.minimization.core.algorithm.dd.impl.ProbabilisticDD
 import org.plan.research.minimization.plugin.execution.DumbCompiler
 import org.plan.research.minimization.plugin.hierarchy.FileTreeHierarchyGenerator
-import org.plan.research.minimization.plugin.model.*
+import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
+import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer
+import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.state.CompilationStrategy
 import org.plan.research.minimization.plugin.model.state.DDStrategy
 import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
+import org.plan.research.minimization.plugin.model.state.SnapshotStrategy
+import org.plan.research.minimization.plugin.snapshot.ProjectCloningSnapshotManager
 
+
+fun SnapshotStrategy.getSnapshotManager(project: Project): SnapshotManager =
+    when (this) {
+        SnapshotStrategy.PROJECT_CLONING -> ProjectCloningSnapshotManager(project)
+    }
 
 fun HierarchyCollectionStrategy.getHierarchyCollectionStrategy(): ProjectHierarchyProducer<*> =
     when (this) {

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/CompilationPropertyChecker.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/CompilationPropertyChecker.kt
@@ -1,4 +1,0 @@
-package org.plan.research.minimization.plugin.errors
-
-sealed interface CompilationPropertyCheckerError
-data object CompilationSuccess : CompilationPropertyCheckerError

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/CompilationPropertyCheckerError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/CompilationPropertyCheckerError.kt
@@ -1,0 +1,5 @@
+package org.plan.research.minimization.plugin.errors
+
+sealed interface CompilationPropertyCheckerError {
+    data object CompilationSuccess : CompilationPropertyCheckerError
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/HierarchyBuildError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/HierarchyBuildError.kt
@@ -1,6 +1,6 @@
 package org.plan.research.minimization.plugin.errors
 
-sealed interface HierarchyBuildError
-
-data object NoRootFound : HierarchyBuildError
-data object NoExceptionFound : HierarchyBuildError
+sealed interface HierarchyBuildError {
+    data object NoRootFound : HierarchyBuildError
+    data object NoExceptionFound : HierarchyBuildError
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/MinimizationError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/MinimizationError.kt
@@ -2,4 +2,5 @@ package org.plan.research.minimization.plugin.errors
 
 sealed interface MinimizationError {
     data class HierarchyFailed(val error: HierarchyBuildError) : MinimizationError
+    data object CloningFailed : MinimizationError
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
@@ -1,0 +1,6 @@
+package org.plan.research.minimization.plugin.errors
+
+sealed interface SnapshotError {
+    data object Aborted : SnapshotError
+    data class TransactionFailed(val error: Throwable) : SnapshotError
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
@@ -3,4 +3,5 @@ package org.plan.research.minimization.plugin.errors
 sealed interface SnapshotError<T> {
     data class Aborted<T>(val reason: T) : SnapshotError<T>
     data class TransactionFailed<T>(val error: Throwable) : SnapshotError<T>
+    data class TransactionCreationFailed<T>(val reason: String) : SnapshotError<T>
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
@@ -1,7 +1,7 @@
 package org.plan.research.minimization.plugin.errors
 
-sealed interface SnapshotError<T> {
+sealed interface SnapshotError<out T> {
     data class Aborted<T>(val reason: T) : SnapshotError<T>
-    data class TransactionFailed<T>(val error: Throwable) : SnapshotError<T>
-    data class TransactionCreationFailed<T>(val reason: String) : SnapshotError<T>
+    data class TransactionFailed(val error: Throwable) : SnapshotError<Nothing>
+    data class TransactionCreationFailed(val reason: String) : SnapshotError<Nothing>
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/errors/SnapshotError.kt
@@ -1,6 +1,6 @@
 package org.plan.research.minimization.plugin.errors
 
-sealed interface SnapshotError {
-    data object Aborted : SnapshotError
-    data class TransactionFailed(val error: Throwable) : SnapshotError
+sealed interface SnapshotError<T> {
+    data class Aborted<T>(val reason: T) : SnapshotError<T>
+    data class TransactionFailed<T>(val error: Throwable) : SnapshotError<T>
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/DumbCompiler.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/DumbCompiler.kt
@@ -1,17 +1,34 @@
 package org.plan.research.minimization.plugin.execution
 
 import arrow.core.Either
-import arrow.core.right
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import org.plan.research.minimization.plugin.errors.CompilationPropertyCheckerError
+import org.plan.research.minimization.plugin.execution.DumbCompiler.targetPaths
 import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
 
 /**
- * A dumb compiler that always gives the same exception
+ * A dumb compiler that checks containing of [targetPaths].
+ *
+ * If [targetPaths] equals null, then [DumbCompiler] always returns new exception
  */
 object DumbCompiler : CompilationPropertyChecker {
     override suspend fun checkCompilation(project: Project): Either<CompilationPropertyCheckerError, Throwable> =
-        THROWABLE.right()
+        either {
+            val paths = targetPaths ?: return@either Throwable()
+
+            val baseDir = project.guessProjectDir() ?: raise(CompilationPropertyCheckerError.CompilationSuccess)
+
+            for (path in paths) {
+                ensureNotNull(baseDir.findFileByRelativePath(path)) { CompilationPropertyCheckerError.CompilationSuccess }
+            }
+
+            THROWABLE
+        }
+
+    var targetPaths: List<String>? = null
 
     private val THROWABLE = Throwable()
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -5,7 +5,6 @@ import arrow.core.raise.option
 import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.utils.vfs.deleteRecursively
 import org.plan.research.minimization.core.model.PropertyTestResult
 import org.plan.research.minimization.core.model.PropertyTester
 import org.plan.research.minimization.core.model.PropertyTesterError
@@ -34,13 +33,13 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
      */
     override suspend fun test(context: IJDDContext, items: List<T>): PropertyTestResult<IJDDContext> =
         snapshotManager.transaction(context) { newContext ->
-            if (context.currentLevel == null) return@transaction newContext
+            val currentLevel = context.currentLevelVirtualFiles ?: return@transaction newContext
 
-            val targetFiles = context.currentLevel.minus(items.toSet()).filterIsInstance<ProjectFileDDItem>()
+            val targetFiles = currentLevel.minus(items.toSet()).filterIsInstance<ProjectFileDDItem>()
 
             writeAction {
                 targetFiles.forEach { item ->
-                    item.getVirtualFile(newContext)?.deleteRecursively()
+                    item.getVirtualFile(newContext)?.delete(this)
                 }
             }
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -30,7 +30,7 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
      * Tests whether the context's project has the same compiler exception as the root one
      *
      * @param context The context containing the current level project to test.
-     * @param items The list of virtual file items to be tested within the context.
+     * @param items The list of project file items to be tested within the context.
      */
     override suspend fun test(context: IJDDContext, items: List<T>): PropertyTestResult<IJDDContext> =
         snapshotManager.transaction(context) { newContext ->

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -13,7 +13,7 @@ import org.plan.research.minimization.core.model.PropertyTesterError
 import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.IJDDItem
-import org.plan.research.minimization.plugin.model.IJDDItem.VirtualFileDDItem
+import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.services.ProjectCloningService
 
 /**
@@ -39,15 +39,10 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
 
         return either {
             ensure(items.isNotEmpty()) { PropertyTesterError.NoProperty }
-            val clonedProject = when (items.firstOrNull()) {
-                null -> cloningService.clone(project, emptyList())
-                is VirtualFileDDItem ->
-                    cloningService
-                        .clone(project, items.filterIsInstance<VirtualFileDDItem>().map(VirtualFileDDItem::vfs))
-                else -> TODO()
-            }
-                ?: raise(PropertyTesterError.UnknownProperty)
 
+            val clonedProject = cloningService.clone(
+                project, items.filterIsInstance<VirtualFileDDItem>().map(VirtualFileDDItem::vfs)
+            ) ?: raise(PropertyTesterError.UnknownProperty)
 
             val compilationResult = compilationPropertyChecker
                 .checkCompilation(clonedProject)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -13,7 +13,7 @@ import org.plan.research.minimization.plugin.errors.SnapshotError
 import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.IJDDItem
-import org.plan.research.minimization.plugin.model.VirtualFileDDItem
+import org.plan.research.minimization.plugin.model.ProjectFileDDItem
 import org.plan.research.minimization.plugin.services.SnapshotManagerService
 
 /**
@@ -36,13 +36,11 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
         snapshotManager.transaction(context) { newContext ->
             if (context.currentLevel == null) return@transaction newContext
 
-            val targetFiles = context.currentLevel.minus(items.toSet()).mapNotNull {
-                (it as? VirtualFileDDItem)?.vfs
-            }
+            val targetFiles = context.currentLevel.minus(items.toSet()).filterIsInstance<ProjectFileDDItem>()
 
             writeAction {
-                targetFiles.forEach { file ->
-                    file.translate()?.deleteRecursively()
+                targetFiles.forEach { item ->
+                    item.getVirtualFile(newContext)?.deleteRecursively()
                 }
             }
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -1,20 +1,20 @@
 package org.plan.research.minimization.plugin.execution
 
 import arrow.core.getOrElse
-import arrow.core.raise.either
-import arrow.core.raise.ensure
 import arrow.core.raise.option
+import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.testFramework.utils.vfs.deleteRecursively
 import org.plan.research.minimization.core.model.PropertyTestResult
 import org.plan.research.minimization.core.model.PropertyTester
 import org.plan.research.minimization.core.model.PropertyTesterError
+import org.plan.research.minimization.plugin.errors.SnapshotError
 import org.plan.research.minimization.plugin.model.CompilationPropertyChecker
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.IJDDItem
 import org.plan.research.minimization.plugin.model.VirtualFileDDItem
-import org.plan.research.minimization.plugin.services.ProjectCloningService
+import org.plan.research.minimization.plugin.services.SnapshotManagerService
 
 /**
  * A property tester for Delta Debugging algorithm that leverages different compilation strategies
@@ -24,40 +24,45 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
     private val compilationPropertyChecker: CompilationPropertyChecker,
     private val initialException: Throwable,
 ) : PropertyTester<IJDDContext, T> {
-    private val cloningService = rootProject.service<ProjectCloningService>()
+    private val snapshotManager = rootProject.service<SnapshotManagerService>()
 
     /**
      * Tests whether the context's project has the same compiler exception as the root one
-     * Closes and disposes the cloned project immediately after checking the compilation.
      *
      * @param context The context containing the current level project to test.
      * @param items The list of virtual file items to be tested within the context.
-     * For the given level all children and parent nodes will be considered as taken
      */
-    override suspend fun test(context: IJDDContext, items: List<T>): PropertyTestResult<IJDDContext> {
-        val project = context.project
+    override suspend fun test(context: IJDDContext, items: List<T>): PropertyTestResult<IJDDContext> =
+        snapshotManager.transaction(context) { newContext ->
+            if (context.currentLevel == null) return@transaction newContext
 
-        return either {
-            ensure(items.isNotEmpty()) { PropertyTesterError.NoProperty }
+            val targetFiles = context.currentLevel.minus(items.toSet()).mapNotNull {
+                (it as? VirtualFileDDItem)?.vfs
+            }
 
-            val clonedProject = cloningService.clone(
-                project, items.filterIsInstance<VirtualFileDDItem>().map(VirtualFileDDItem::vfs)
-            ) ?: raise(PropertyTesterError.UnknownProperty)
+            writeAction {
+                targetFiles.forEach { file ->
+                    file.translate().deleteRecursively()
+                }
+            }
 
             val compilationResult = compilationPropertyChecker
-                .checkCompilation(clonedProject)
-                .also { ProjectManagerEx.getInstanceEx().closeAndDispose(clonedProject) } // Close immediately
+                .checkCompilation(newContext.project)
                 .getOrElse { raise(PropertyTesterError.NoProperty) }
 
             when (compilationResult) {
-                initialException -> IJDDContext(project)
+                initialException -> newContext
                 else -> raise(PropertyTesterError.UnknownProperty)
             }
+        }.mapLeft {
+            when (it) {
+                is SnapshotError.Aborted -> it.reason
+                is SnapshotError.TransactionFailed -> PropertyTesterError.UnknownProperty
+            }
         }
-    }
 
     companion object {
-        suspend fun<T: IJDDItem> create(
+        suspend fun <T : IJDDItem> create(
             compilerPropertyChecker: CompilationPropertyChecker,
             project: Project
         ) = option {

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -42,7 +42,7 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
 
             writeAction {
                 targetFiles.forEach { file ->
-                    file.translate().deleteRecursively()
+                    file.translate()?.deleteRecursively()
                 }
             }
 
@@ -57,7 +57,7 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
         }.mapLeft {
             when (it) {
                 is SnapshotError.Aborted -> it.reason
-                is SnapshotError.TransactionFailed -> PropertyTesterError.UnknownProperty
+                else -> PropertyTesterError.UnknownProperty
             }
         }
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
@@ -9,7 +9,7 @@ import org.plan.research.minimization.core.algorithm.dd.hierarchical.HDDLevel
 import org.plan.research.minimization.core.algorithm.dd.hierarchical.HierarchicalDDGenerator
 import org.plan.research.minimization.core.model.PropertyTester
 import org.plan.research.minimization.plugin.model.IJDDContext
-import org.plan.research.minimization.plugin.model.IJDDItem.VirtualFileDDItem
+import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.services.ProjectCloningService
 
 class FileTreeHierarchicalDDGenerator(

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
@@ -1,7 +1,6 @@
 package org.plan.research.minimization.plugin.hierarchy
 
 import arrow.core.raise.option
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithmResult
 import org.plan.research.minimization.core.algorithm.dd.hierarchical.HDDLevel
@@ -11,19 +10,19 @@ import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 
 class FileTreeHierarchicalDDGenerator(
-    val project: Project,
     private val propertyTester: PropertyTester<IJDDContext, VirtualFileDDItem>
 ) : HierarchicalDDGenerator<IJDDContext, VirtualFileDDItem> {
-    override suspend fun generateFirstLevel(): HDDLevel<IJDDContext, VirtualFileDDItem> {
-        val projectRoot = project.guessProjectDir()
-        val level = listOfNotNull(projectRoot).map { VirtualFileDDItem(it)}
-        return HDDLevel(IJDDContext(project, level), level, propertyTester)
-    }
+    override suspend fun generateFirstLevel(context: IJDDContext) =
+        option {
+            val projectRoot = ensureNotNull(context.project.guessProjectDir())
+            val level = listOf(projectRoot).map { VirtualFileDDItem(it) }
+            HDDLevel(context.copy(currentLevel = level), level, propertyTester)
+        }
 
     override suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<IJDDContext, VirtualFileDDItem>) =
         option {
             val nextFiles = minimizationResult.items.flatMap { it.vfs.children.asList() }.map { VirtualFileDDItem(it) }
             ensure(nextFiles.isNotEmpty())
             HDDLevel(minimizationResult.context.copy(currentLevel = nextFiles), nextFiles, propertyTester)
-        }.getOrNull()
+        }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
@@ -14,6 +14,7 @@ class FileTreeHierarchicalDDGenerator(
 ) : HierarchicalDDGenerator<IJDDContext, ProjectFileDDItem> {
     override suspend fun generateFirstLevel(context: IJDDContext) =
         option {
+            // TODO: take first level as root's children
             val level = listOf(ProjectFileDDItem(Path("")))
             HDDLevel(context.copy(currentLevel = level), level, propertyTester)
         }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
@@ -1,27 +1,31 @@
 package org.plan.research.minimization.plugin.hierarchy
 
 import arrow.core.raise.option
-import com.intellij.openapi.project.guessProjectDir
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithmResult
 import org.plan.research.minimization.core.algorithm.dd.hierarchical.HDDLevel
 import org.plan.research.minimization.core.algorithm.dd.hierarchical.HierarchicalDDGenerator
 import org.plan.research.minimization.core.model.PropertyTester
 import org.plan.research.minimization.plugin.model.IJDDContext
-import org.plan.research.minimization.plugin.model.VirtualFileDDItem
+import org.plan.research.minimization.plugin.model.ProjectFileDDItem
+import kotlin.io.path.Path
 
 class FileTreeHierarchicalDDGenerator(
-    private val propertyTester: PropertyTester<IJDDContext, VirtualFileDDItem>
-) : HierarchicalDDGenerator<IJDDContext, VirtualFileDDItem> {
+    private val propertyTester: PropertyTester<IJDDContext, ProjectFileDDItem>
+) : HierarchicalDDGenerator<IJDDContext, ProjectFileDDItem> {
     override suspend fun generateFirstLevel(context: IJDDContext) =
         option {
-            val projectRoot = ensureNotNull(context.project.guessProjectDir())
-            val level = listOf(projectRoot).map { VirtualFileDDItem(it) }
+            val level = listOf(ProjectFileDDItem(Path("")))
             HDDLevel(context.copy(currentLevel = level), level, propertyTester)
         }
 
-    override suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<IJDDContext, VirtualFileDDItem>) =
+    override suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<IJDDContext, ProjectFileDDItem>) =
         option {
-            val nextFiles = minimizationResult.items.flatMap { it.vfs.children.asList() }.map { VirtualFileDDItem(it) }
+            val nextFiles = minimizationResult.items.flatMap {
+                val vf = it.getVirtualFile(minimizationResult.context) ?: return@flatMap emptyList()
+                vf.children.map { file ->
+                    ProjectFileDDItem.create(minimizationResult.context, file)
+                }
+            }
             ensure(nextFiles.isNotEmpty())
             HDDLevel(minimizationResult.context.copy(currentLevel = nextFiles), nextFiles, propertyTester)
         }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchicalDDGenerator.kt
@@ -1,7 +1,6 @@
 package org.plan.research.minimization.plugin.hierarchy
 
 import arrow.core.raise.option
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithmResult
@@ -10,32 +9,21 @@ import org.plan.research.minimization.core.algorithm.dd.hierarchical.Hierarchica
 import org.plan.research.minimization.core.model.PropertyTester
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.VirtualFileDDItem
-import org.plan.research.minimization.plugin.services.ProjectCloningService
 
 class FileTreeHierarchicalDDGenerator(
     val project: Project,
     private val propertyTester: PropertyTester<IJDDContext, VirtualFileDDItem>
 ) : HierarchicalDDGenerator<IJDDContext, VirtualFileDDItem> {
-    private val projectCloner = project.service<ProjectCloningService>()
     override suspend fun generateFirstLevel(): HDDLevel<IJDDContext, VirtualFileDDItem> {
         val projectRoot = project.guessProjectDir()
-        val level = listOfNotNull(projectRoot)
-        return HDDLevel(IJDDContext(project), level.map { VirtualFileDDItem(it) }, propertyTester)
+        val level = listOfNotNull(projectRoot).map { VirtualFileDDItem(it)}
+        return HDDLevel(IJDDContext(project, level), level, propertyTester)
     }
 
     override suspend fun generateNextLevel(minimizationResult: DDAlgorithmResult<IJDDContext, VirtualFileDDItem>) =
         option {
             val nextFiles = minimizationResult.items.flatMap { it.vfs.children.asList() }.map { VirtualFileDDItem(it) }
             ensure(nextFiles.isNotEmpty())
-            val newProjectVersion =
-                projectCloner.clone(minimizationResult.context.project, nextFiles.map(VirtualFileDDItem::vfs))
-            ensureNotNull(newProjectVersion)
-            HDDLevel(
-                items = nextFiles,
-                context = minimizationResult.context.copy(
-                    project = newProjectVersion,
-                ),
-                propertyTester = propertyTester
-            )
+            HDDLevel(minimizationResult.context.copy(currentLevel = nextFiles), nextFiles, propertyTester)
         }.getOrNull()
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
@@ -11,7 +11,7 @@ import org.plan.research.minimization.plugin.errors.HierarchyBuildError
 import org.plan.research.minimization.plugin.errors.NoExceptionFound
 import org.plan.research.minimization.plugin.errors.NoRootFound
 import org.plan.research.minimization.plugin.execution.SameExceptionPropertyTester
-import org.plan.research.minimization.plugin.model.IJDDItem.VirtualFileDDItem
+import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer
 import org.plan.research.minimization.plugin.services.CompilationPropertyCheckerService
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
@@ -8,8 +8,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import org.plan.research.minimization.plugin.errors.HierarchyBuildError
-import org.plan.research.minimization.plugin.errors.NoExceptionFound
-import org.plan.research.minimization.plugin.errors.NoRootFound
+import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoExceptionFound
+import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoRootFound
 import org.plan.research.minimization.plugin.execution.SameExceptionPropertyTester
 import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
@@ -11,17 +11,17 @@ import org.plan.research.minimization.plugin.errors.HierarchyBuildError
 import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoExceptionFound
 import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoRootFound
 import org.plan.research.minimization.plugin.execution.SameExceptionPropertyTester
+import org.plan.research.minimization.plugin.model.ProjectFileDDItem
 import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer
-import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.services.CompilationPropertyCheckerService
 
-class FileTreeHierarchyGenerator : ProjectHierarchyProducer<VirtualFileDDItem> {
+class FileTreeHierarchyGenerator : ProjectHierarchyProducer<ProjectFileDDItem> {
     override suspend fun produce(
         from: Project
     ): Either<HierarchyBuildError, FileTreeHierarchicalDDGenerator> = either {
         ensureNotNull(from.guessProjectDir()) { NoRootFound }
         val compilerPropertyTester = from.service<CompilationPropertyCheckerService>()
-        val propertyTester = SameExceptionPropertyTester.create<VirtualFileDDItem>(compilerPropertyTester, from)
+        val propertyTester = SameExceptionPropertyTester.create<ProjectFileDDItem>(compilerPropertyTester, from)
             .getOrElse { raise(NoExceptionFound) }
         FileTreeHierarchicalDDGenerator(propertyTester)
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/hierarchy/FileTreeHierarchyGenerator.kt
@@ -11,8 +11,8 @@ import org.plan.research.minimization.plugin.errors.HierarchyBuildError
 import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoExceptionFound
 import org.plan.research.minimization.plugin.errors.HierarchyBuildError.NoRootFound
 import org.plan.research.minimization.plugin.execution.SameExceptionPropertyTester
-import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.model.ProjectHierarchyProducer
+import org.plan.research.minimization.plugin.model.VirtualFileDDItem
 import org.plan.research.minimization.plugin.services.CompilationPropertyCheckerService
 
 class FileTreeHierarchyGenerator : ProjectHierarchyProducer<VirtualFileDDItem> {
@@ -23,6 +23,6 @@ class FileTreeHierarchyGenerator : ProjectHierarchyProducer<VirtualFileDDItem> {
         val compilerPropertyTester = from.service<CompilationPropertyCheckerService>()
         val propertyTester = SameExceptionPropertyTester.create<VirtualFileDDItem>(compilerPropertyTester, from)
             .getOrElse { raise(NoExceptionFound) }
-        FileTreeHierarchicalDDGenerator(from, propertyTester)
+        FileTreeHierarchicalDDGenerator(propertyTester)
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/DDStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/DDStrategy.kt
@@ -1,5 +1,0 @@
-package org.plan.research.minimization.plugin.model
-
-enum class DDStrategy {
-    DD_MIN, PROBABILISTIC_DD
-}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/HierarchyCollectionStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/HierarchyCollectionStrategy.kt
@@ -1,5 +1,0 @@
-package org.plan.research.minimization.plugin.model
-
-enum class HierarchyCollectionStrategy {
-    FILE_TREE
-}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
 import org.plan.research.minimization.core.model.DDContext
+import org.plan.research.minimization.plugin.toVirtualFiles
 
 
 /**
@@ -19,4 +20,5 @@ data class IJDDContext(
     val currentLevel: List<ProjectFileDDItem>? = null,
 ) : DDContext {
     val projectDir: VirtualFile by lazy { project.guessProjectDir()!! }
+    val currentLevelVirtualFiles: List<VirtualFile>? by lazy { currentLevel?.toVirtualFiles(this) }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
@@ -5,6 +5,14 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
 import org.plan.research.minimization.core.model.DDContext
 
+
+/**
+ * Represents a context for the minimization process containing the current project and derived properties.
+ *
+ * @property project The current project to be minimized.
+ * @property originalProject The original project before any minimization stages, defaults to [project].
+ * @property currentLevel An optional list of [ProjectFileDDItem] representing the current level of the minimizing project files.
+ */
 data class IJDDContext(
     val project: Project,
     val originalProject: Project = project,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
@@ -3,7 +3,7 @@ package org.plan.research.minimization.plugin.model
 import com.intellij.openapi.project.Project
 import org.plan.research.minimization.core.model.DDContext
 
-// FIXME: In the current implementation the projects are not closed and disposed which leads to memory leaks.
-//  Need to adjust the architecture to comprehend this.
-//  E.g. fix the moment when the project is closed or replace project with `Path` and open the project each time it needed
-data class IJDDContext(val project: Project) : DDContext
+data class IJDDContext(
+    val project: Project,
+    val currentLevel: List<VirtualFileDDItem>? = null,
+) : DDContext

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDContext.kt
@@ -1,9 +1,14 @@
 package org.plan.research.minimization.plugin.model
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VirtualFile
 import org.plan.research.minimization.core.model.DDContext
 
 data class IJDDContext(
     val project: Project,
-    val currentLevel: List<VirtualFileDDItem>? = null,
-) : DDContext
+    val originalProject: Project = project,
+    val currentLevel: List<ProjectFileDDItem>? = null,
+) : DDContext {
+    val projectDir: VirtualFile by lazy { project.guessProjectDir()!! }
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
@@ -1,8 +1,10 @@
 package org.plan.research.minimization.plugin.model
 
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import org.plan.research.minimization.core.model.DDItem
 
-sealed interface IJDDItem : DDItem {
-    data class VirtualFileDDItem(val vfs: VirtualFile): IJDDItem
-}
+sealed interface IJDDItem : DDItem
+
+data class VirtualFileDDItem(val vfs: VirtualFile) : IJDDItem
+data class PsiDDItem(val psi: PsiElement) : IJDDItem

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
@@ -3,8 +3,19 @@ package org.plan.research.minimization.plugin.model
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import org.plan.research.minimization.core.model.DDItem
+import java.nio.file.Path
+import kotlin.io.path.relativeTo
 
 sealed interface IJDDItem : DDItem
 
-data class VirtualFileDDItem(val vfs: VirtualFile) : IJDDItem
+data class ProjectFileDDItem(val localPath: Path) : IJDDItem {
+    fun getVirtualFile(context: IJDDContext): VirtualFile? =
+        context.projectDir.findFileByRelativePath(localPath.toString())
+
+    companion object {
+        fun create(context: IJDDContext, virtualFile: VirtualFile): ProjectFileDDItem =
+            ProjectFileDDItem(virtualFile.toNioPath().relativeTo(context.projectDir.toNioPath()))
+    }
+}
+
 data class PsiDDItem(val psi: PsiElement) : IJDDItem

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/IJDDItem.kt
@@ -8,6 +8,12 @@ import kotlin.io.path.relativeTo
 
 sealed interface IJDDItem : DDItem
 
+/**
+ * Represents a project file item in the minimization process.
+ *
+ * @property localPath The local path of the file within the project directory.
+ * @constructor Creates an instance of [ProjectFileDDItem] with the specified local path.
+ */
 data class ProjectFileDDItem(val localPath: Path) : IJDDItem {
     fun getVirtualFile(context: IJDDContext): VirtualFile? =
         context.projectDir.findFileByRelativePath(localPath.toString())
@@ -17,5 +23,3 @@ data class ProjectFileDDItem(val localPath: Path) : IJDDItem {
             ProjectFileDDItem(virtualFile.toNioPath().relativeTo(context.projectDir.toNioPath()))
     }
 }
-
-data class PsiDDItem(val psi: PsiElement) : IJDDItem

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/MinimizationStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/MinimizationStage.kt
@@ -3,6 +3,8 @@ package org.plan.research.minimization.plugin.model
 import arrow.core.Either
 import com.intellij.util.xmlb.annotations.Tag
 import org.plan.research.minimization.plugin.errors.MinimizationError
+import org.plan.research.minimization.plugin.model.state.DDStrategy
+import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
 
 interface MinimizationStageExecutor {
     suspend fun executeFileLevelStage(

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/SnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/SnapshotManager.kt
@@ -1,0 +1,24 @@
+package org.plan.research.minimization.plugin.model
+
+import arrow.core.Either
+import arrow.core.raise.OptionRaise
+import org.plan.research.minimization.plugin.errors.SnapshotError
+
+
+/**
+ * The `SnapshotManager` interface provides a mechanism to handle transactions within a given context.
+ */
+interface SnapshotManager {
+
+    /**
+     * Executes a transaction within the provided context. It should create a copy of the context with a new project.
+     *
+     * @param context The context in which the transaction is executed.
+     * @param action A suspendable lambda function representing the transaction action to be performed.
+     * @return Either a `SnapshotError` if the transaction fails, or the updated `IJDDContext` if the transaction succeeds.
+     */
+    suspend fun transaction(
+        context: IJDDContext,
+        action: suspend OptionRaise.(newContext: IJDDContext) -> IJDDContext,
+    ): Either<SnapshotError, IJDDContext>
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/SnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/SnapshotManager.kt
@@ -1,8 +1,8 @@
-package org.plan.research.minimization.plugin.model
+package org.plan.research.minimization.plugin.model.snapshot
 
 import arrow.core.Either
-import arrow.core.raise.OptionRaise
 import org.plan.research.minimization.plugin.errors.SnapshotError
+import org.plan.research.minimization.plugin.model.IJDDContext
 
 
 /**
@@ -11,14 +11,14 @@ import org.plan.research.minimization.plugin.errors.SnapshotError
 interface SnapshotManager {
 
     /**
-     * Executes a transaction within the provided context. It should create a copy of the context with a new project.
+     * Executes a transaction within the provided context.
      *
      * @param context The context in which the transaction is executed.
      * @param action A suspendable lambda function representing the transaction action to be performed.
      * @return Either a `SnapshotError` if the transaction fails, or the updated `IJDDContext` if the transaction succeeds.
      */
-    suspend fun transaction(
+    suspend fun <T> transaction(
         context: IJDDContext,
-        action: suspend OptionRaise.(newContext: IJDDContext) -> IJDDContext,
-    ): Either<SnapshotError, IJDDContext>
+        action: suspend TransactionBody<T>.(newContext: IJDDContext) -> IJDDContext,
+    ): Either<SnapshotError<T>, IJDDContext>
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionBody.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionBody.kt
@@ -1,0 +1,8 @@
+package org.plan.research.minimization.plugin.model.snapshot
+
+import arrow.core.raise.Raise
+
+class TransactionBody<T>(
+    raise: Raise<T>,
+    translator: TransactionTranslator
+) : Raise<T> by raise, TransactionTranslator by translator

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionBody.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionBody.kt
@@ -4,5 +4,4 @@ import arrow.core.raise.Raise
 
 class TransactionBody<T>(
     raise: Raise<T>,
-    translator: TransactionTranslator
-) : Raise<T> by raise, TransactionTranslator by translator
+) : Raise<T> by raise

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
@@ -1,7 +1,0 @@
-package org.plan.research.minimization.plugin.model.snapshot
-
-import com.intellij.openapi.vfs.VirtualFile
-
-interface TransactionTranslator {
-    fun VirtualFile.translate(): VirtualFile?
-}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
@@ -3,5 +3,5 @@ package org.plan.research.minimization.plugin.model.snapshot
 import com.intellij.openapi.vfs.VirtualFile
 
 interface TransactionTranslator {
-    fun VirtualFile.translate(): VirtualFile
+    fun VirtualFile.translate(): VirtualFile?
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/snapshot/TransactionTranslator.kt
@@ -1,0 +1,7 @@
+package org.plan.research.minimization.plugin.model.snapshot
+
+import com.intellij.openapi.vfs.VirtualFile
+
+interface TransactionTranslator {
+    fun VirtualFile.translate(): VirtualFile
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/CompilationStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/CompilationStrategy.kt
@@ -1,4 +1,4 @@
-package org.plan.research.minimization.plugin.model
+package org.plan.research.minimization.plugin.model.state
 
 enum class CompilationStrategy {
     DUMB, // Return the same exception every time. Used for testing

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/DDStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/DDStrategy.kt
@@ -1,0 +1,5 @@
+package org.plan.research.minimization.plugin.model.state
+
+enum class DDStrategy {
+    DD_MIN, PROBABILISTIC_DD
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/HierarchyCollectionStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/HierarchyCollectionStrategy.kt
@@ -1,0 +1,5 @@
+package org.plan.research.minimization.plugin.model.state
+
+enum class HierarchyCollectionStrategy {
+    FILE_TREE
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/SnapshotStrategy.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/state/SnapshotStrategy.kt
@@ -1,0 +1,5 @@
+package org.plan.research.minimization.plugin.model.state
+
+enum class SnapshotStrategy {
+    PROJECT_CLONING,
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationService.kt
@@ -13,10 +13,16 @@ import org.plan.research.minimization.plugin.settings.MinimizationPluginSettings
 class MinimizationService(project: Project, private val coroutineScope: CoroutineScope) {
     private val stages = project.service<MinimizationPluginSettings>().state.stages
     private val executor = project.service<MinimizationStageExecutorService>()
+    private val projectCloning = project.service<ProjectCloningService>()
 
      fun minimizeProject(project: Project) = coroutineScope.launch {
+         val clonedProject = projectCloning.clone(project)
+         if (clonedProject == null) {
+             println("Failed to clone project")
+             return@launch
+         }
          val result = either {
-             var currentProject = IJDDContext(project)
+             var currentProject = IJDDContext(clonedProject)
              for (stage in stages) {
                  currentProject = stage.apply(currentProject, executor).bind()
              }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
@@ -8,8 +8,8 @@ import org.plan.research.minimization.plugin.errors.MinimizationError
 import org.plan.research.minimization.plugin.getDDAlgorithm
 import org.plan.research.minimization.plugin.getHierarchyCollectionStrategy
 import org.plan.research.minimization.plugin.model.FileLevelStage
-import org.plan.research.minimization.plugin.model.MinimizationStageExecutor
 import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.model.MinimizationStageExecutor
 
 @Service(Service.Level.PROJECT)
 class MinimizationStageExecutorService : MinimizationStageExecutor {
@@ -21,7 +21,7 @@ class MinimizationStageExecutorService : MinimizationStageExecutor {
             .getHierarchyCollectionStrategy()
             .produce(context.project)
             .getOrElse { raise(MinimizationError.HierarchyFailed(it)) }
-        hierarchicalDD.minimize(hierarchy)
+        hierarchicalDD.minimize(context, hierarchy)
     }
 }
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
@@ -19,7 +19,7 @@ class MinimizationStageExecutorService : MinimizationStageExecutor {
         val hierarchy = fileLevelStage
             .hierarchyCollectionStrategy
             .getHierarchyCollectionStrategy()
-            .produce(context.project)
+            .produce(context.originalProject)
             .getOrElse { raise(MinimizationError.HierarchyFailed(it)) }
         hierarchicalDD.minimize(context, hierarchy)
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/ProjectCloningService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/ProjectCloningService.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findOrCreateDirectory
@@ -28,7 +30,7 @@ class ProjectCloningService(private val rootProject: Project) {
     /**
      * Perform a full clone of the project
      * @param project A project to clone
-     * @return a cloned project or null if the project was default
+     * @return a cloned project
      */
     suspend fun clone(project: Project): Project? {
         val clonedProjectPath = createNewProjectDirectory()

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/ProjectCloningService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/ProjectCloningService.kt
@@ -9,8 +9,6 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findOrCreateDirectory
-import org.plan.research.minimization.plugin.getAllNestedElements
-import org.plan.research.minimization.plugin.getAllParents
 import org.plan.research.minimization.plugin.settings.MinimizationPluginSettings
 import java.util.*
 
@@ -33,43 +31,27 @@ class ProjectCloningService(private val rootProject: Project) {
      * @return a cloned project or null if the project was default
      */
     suspend fun clone(project: Project): Project? {
-        val projectRoot = project.guessProjectDir() ?: return null
-        return clone(project, projectRoot.getAllNestedElements())
-    }
-
-    /**
-     * Perform a partial clone of the project
-     * @param project A project to clone
-     * @param items all files and directories that should be copied over from the original project including parent directories
-     */
-    suspend fun clone(project: Project, items: List<VirtualFile>): Project? {
         val clonedProjectPath = createNewProjectDirectory()
         val projectRoot = project.guessProjectDir() ?: return null
-        val snapshotLocation = getSnapshotLocation()
-        val itemsWithParents = items.getAllParents(projectRoot).toSet() + items.flatMap { it.getAllNestedElements() }.toSet()
         writeAction {
+            val snapshotLocation = getSnapshotLocation()
             VfsUtil.copyDirectory(
                 this,
                 projectRoot,
                 clonedProjectPath
-            ) { it in itemsWithParents && it.path != snapshotLocation.path }
+            ) { it.path != snapshotLocation.path }
         }
         return ProjectUtil.openOrImportAsync(clonedProjectPath.toNioPath())
     }
 
     @Suppress("UnstableApiUsage")
-    private suspend fun createNewProjectDirectory(): VirtualFile {
-        val tempDirectory = getSnapshotLocation()
-        return writeAction {
-            tempDirectory
-                .findOrCreateDirectory(UUID.randomUUID().toString())
-        }
+    private suspend fun createNewProjectDirectory(): VirtualFile = writeAction {
+        getSnapshotLocation().findOrCreateDirectory(UUID.randomUUID().toString())
     }
 
-    private suspend fun getSnapshotLocation(): VirtualFile = writeAction {
+    private fun getSnapshotLocation(): VirtualFile =
         rootProject
             .guessProjectDir()
             ?.findOrCreateDirectory(tempProjectsDirectoryName)
             ?: rootProject.guessProjectDir()!!
-    }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/SnapshotManagerService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/SnapshotManagerService.kt
@@ -1,0 +1,26 @@
+package org.plan.research.minimization.plugin.services
+
+import arrow.core.Either
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import org.plan.research.minimization.plugin.errors.SnapshotError
+import org.plan.research.minimization.plugin.getSnapshotManager
+import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
+import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
+import org.plan.research.minimization.plugin.settings.MinimizationPluginSettings
+
+@Service(Service.Level.PROJECT)
+class SnapshotManagerService(private val rootProject: Project) : SnapshotManager {
+    private val underlyingObject: SnapshotManager
+        get() = rootProject
+            .service<MinimizationPluginSettings>()
+            .state.snapshotStrategy
+            .getSnapshotManager(rootProject)
+
+    override suspend fun <T> transaction(
+        context: IJDDContext,
+        action: suspend TransactionBody<T>.(newContext: IJDDContext) -> IJDDContext
+    ): Either<SnapshotError<T>, IJDDContext> = underlyingObject.transaction(context, action)
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/MinimizationPluginState.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/MinimizationPluginState.kt
@@ -3,10 +3,12 @@ package org.plan.research.minimization.plugin.settings
 import com.intellij.openapi.components.BaseState
 import com.intellij.util.xmlb.annotations.Property
 import com.intellij.util.xmlb.annotations.XCollection
-import org.plan.research.minimization.plugin.model.*
+import org.plan.research.minimization.plugin.model.FileLevelStage
+import org.plan.research.minimization.plugin.model.MinimizationStage
 import org.plan.research.minimization.plugin.model.state.CompilationStrategy
 import org.plan.research.minimization.plugin.model.state.DDStrategy
 import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
+import org.plan.research.minimization.plugin.model.state.SnapshotStrategy
 
 class MinimizationPluginState : BaseState() {
     var currentCompilationStrategy by enum<CompilationStrategy>(CompilationStrategy.GRADLE_IDEA)
@@ -15,6 +17,7 @@ class MinimizationPluginState : BaseState() {
      * A location for cloned projects
      */
     var temporaryProjectLocation by string("minimization-project-snapshots")
+    var snapshotStrategy by enum<SnapshotStrategy>(SnapshotStrategy.PROJECT_CLONING)
 
     @Property(surroundWithTag = false)
     @XCollection(style = XCollection.Style.v1, elementName = "stage")

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/MinimizationPluginState.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/MinimizationPluginState.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.components.BaseState
 import com.intellij.util.xmlb.annotations.Property
 import com.intellij.util.xmlb.annotations.XCollection
 import org.plan.research.minimization.plugin.model.*
+import org.plan.research.minimization.plugin.model.state.CompilationStrategy
+import org.plan.research.minimization.plugin.model.state.DDStrategy
+import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
 
 class MinimizationPluginState : BaseState() {
     var currentCompilationStrategy by enum<CompilationStrategy>(CompilationStrategy.GRADLE_IDEA)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
@@ -1,17 +1,61 @@
 package org.plan.research.minimization.plugin.snapshot
 
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.raise.either
+import arrow.core.raise.withError
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VirtualFile
 import org.plan.research.minimization.plugin.errors.SnapshotError
+import org.plan.research.minimization.plugin.errors.SnapshotError.*
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
+import org.plan.research.minimization.plugin.model.snapshot.TransactionTranslator
+import org.plan.research.minimization.plugin.services.ProjectCloningService
 
-class ProjectCloningSnapshotManager(private val rootProject: Project) : SnapshotManager {
+class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
+    private val projectCloning = rootProject.service<ProjectCloningService>()
+
     override suspend fun <T> transaction(
         context: IJDDContext,
         action: suspend TransactionBody<T>.(newContext: IJDDContext) -> IJDDContext
     ): Either<SnapshotError<T>, IJDDContext> {
-        TODO("Not yet implemented")
+        val clonedProject = projectCloning.clone(context.project)
+            ?: return TransactionCreationFailed<T>("Failed to create project").left()
+
+        return either<SnapshotError<T>, IJDDContext> {
+            val translator = withError(::TransactionCreationFailed) {
+                val sourcePath = context.project.guessProjectDir()?.path
+                    ?: raise("Failed to get source path")
+                val clonedProjectDir = context.project.guessProjectDir()
+                    ?: raise("Failed to get cloned project dir")
+                Translator(clonedProjectDir, sourcePath)
+            }
+
+            try {
+                withError(::Aborted) {
+                    val transaction = TransactionBody<T>(this@withError, translator)
+                    transaction.action(context.copy(project = clonedProject))
+                }
+            } catch (e: Throwable) {
+                raise(TransactionFailed(e))
+            }
+        }.onLeft {
+            ProjectManager.getInstance().closeAndDispose(clonedProject)
+        }.onRight {
+            ProjectManager.getInstance().closeAndDispose(context.project)
+        }
+    }
+
+    private inner class Translator(
+        val clonedProjectDir: VirtualFile,
+        val originalPath: String,
+    ) : TransactionTranslator {
+        override fun VirtualFile.translate(): VirtualFile? =
+            clonedProjectDir.findFileByRelativePath(path.removePrefix(originalPath))
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
@@ -14,32 +14,54 @@ import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
 import org.plan.research.minimization.plugin.services.ProjectCloningService
 
+/**
+ * Manages the creation and handling of project cloning snapshots for transactions.
+ *
+ * @param rootProject The root project used to access services.
+ */
 class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
     private val projectCloning = rootProject.service<ProjectCloningService>()
 
+    /**
+     * Executes a transaction within the provided context,
+     * typically involving project cloning and rollback upon failures.
+     *
+     * Transaction guarantees that:
+     * - Cloned project is closed if a transaction fails.
+     * - If a transaction is successful, the project of the [context] is closed.
+     *
+     * @param T The type parameter indicating the type of any raised error during the transaction.
+     * @param context The `IJDDContext` containing the project and associated data needed to perform the transaction.
+     * @param action A suspendable lambda function that takes a new transactional context and returns the updated context.
+     * @return Either a `SnapshotError` encapsulating the error in case of failure, or the updated `IJDDContext` in case of success.
+     */
     override suspend fun <T> transaction(
         context: IJDDContext,
         action: suspend TransactionBody<T>.(newContext: IJDDContext) -> IJDDContext
     ): Either<SnapshotError<T>, IJDDContext> = either {
         val clonedProject = projectCloning.clone(context.project)
             ?: raise(TransactionCreationFailed("Failed to create project"))
+        val clonedContext = context.copy(project = clonedProject)
 
         try {
             recover<T, _>(
                 block = {
                     val transaction = TransactionBody(this@recover)
-                    transaction.action(context.copy(project = clonedProject))
+                    transaction.action(clonedContext)
                 },
                 recover = { raise(Aborted(it)) },
                 catch = { raise(TransactionFailed(it)) },
             )
         } catch (e: Throwable) {
-            invokeLater {
-                ProjectManager.getInstance().closeAndDispose(clonedProject)
-            }
+            closeProject(clonedContext)
             throw e
         }
     }.onRight {
+        closeProject(context)
+    }
+
+    private fun closeProject(context: IJDDContext) {
+        // TODO: think about deleting the project
         invokeLater {
             ProjectManager.getInstance().closeAndDispose(context.project)
         }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
@@ -18,6 +18,9 @@ import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
 import org.plan.research.minimization.plugin.model.snapshot.TransactionTranslator
 import org.plan.research.minimization.plugin.services.ProjectCloningService
+import java.nio.file.Path
+import kotlin.io.path.pathString
+import kotlin.io.path.relativeTo
 
 class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
     private val projectCloning = rootProject.service<ProjectCloningService>()
@@ -31,7 +34,7 @@ class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
 
         try {
             val translator = withError(::TransactionCreationFailed) {
-                val sourcePath = context.project.guessProjectDir()?.path
+                val sourcePath = context.project.guessProjectDir()?.toNioPath()
                     ?: raise("Failed to get source path")
                 val clonedProjectDir = context.project.guessProjectDir()
                     ?: raise("Failed to get cloned project dir")
@@ -61,9 +64,9 @@ class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
 
     private inner class Translator(
         val clonedProjectDir: VirtualFile,
-        val originalPath: String,
+        val originalPath: Path,
     ) : TransactionTranslator {
         override fun VirtualFile.translate(): VirtualFile? =
-            clonedProjectDir.findFileByRelativePath(path.removePrefix(originalPath))
+            clonedProjectDir.findFileByRelativePath(toNioPath().relativeTo(originalPath).pathString)
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
@@ -1,0 +1,17 @@
+package org.plan.research.minimization.plugin.snapshot
+
+import arrow.core.Either
+import com.intellij.openapi.project.Project
+import org.plan.research.minimization.plugin.errors.SnapshotError
+import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
+import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
+
+class ProjectCloningSnapshotManager(private val rootProject: Project) : SnapshotManager {
+    override suspend fun <T> transaction(
+        context: IJDDContext,
+        action: suspend TransactionBody<T>.(newContext: IJDDContext) -> IJDDContext
+    ): Either<SnapshotError<T>, IJDDContext> {
+        TODO("Not yet implemented")
+    }
+}

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/snapshot/ProjectCloningSnapshotManager.kt
@@ -1,26 +1,18 @@
 package org.plan.research.minimization.plugin.snapshot
 
 import arrow.core.Either
-import arrow.core.identity
 import arrow.core.raise.either
-import arrow.core.raise.fold
-import arrow.core.raise.withError
+import arrow.core.raise.recover
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.vfs.VirtualFile
 import org.plan.research.minimization.plugin.errors.SnapshotError
 import org.plan.research.minimization.plugin.errors.SnapshotError.*
 import org.plan.research.minimization.plugin.model.IJDDContext
 import org.plan.research.minimization.plugin.model.snapshot.SnapshotManager
 import org.plan.research.minimization.plugin.model.snapshot.TransactionBody
-import org.plan.research.minimization.plugin.model.snapshot.TransactionTranslator
 import org.plan.research.minimization.plugin.services.ProjectCloningService
-import java.nio.file.Path
-import kotlin.io.path.pathString
-import kotlin.io.path.relativeTo
 
 class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
     private val projectCloning = rootProject.service<ProjectCloningService>()
@@ -33,22 +25,13 @@ class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
             ?: raise(TransactionCreationFailed("Failed to create project"))
 
         try {
-            val translator = withError(::TransactionCreationFailed) {
-                val sourcePath = context.project.guessProjectDir()?.toNioPath()
-                    ?: raise("Failed to get source path")
-                val clonedProjectDir = context.project.guessProjectDir()
-                    ?: raise("Failed to get cloned project dir")
-                Translator(clonedProjectDir, sourcePath)
-            }
-
-            fold<T, _, _>(
+            recover<T, _>(
                 block = {
-                    val transaction = TransactionBody(this@fold, translator)
+                    val transaction = TransactionBody(this@recover)
                     transaction.action(context.copy(project = clonedProject))
                 },
-                catch = { raise(TransactionFailed(it)) },
                 recover = { raise(Aborted(it)) },
-                transform = ::identity,
+                catch = { raise(TransactionFailed(it)) },
             )
         } catch (e: Throwable) {
             invokeLater {
@@ -60,13 +43,5 @@ class ProjectCloningSnapshotManager(rootProject: Project) : SnapshotManager {
         invokeLater {
             ProjectManager.getInstance().closeAndDispose(context.project)
         }
-    }
-
-    private inner class Translator(
-        val clonedProjectDir: VirtualFile,
-        val originalPath: Path,
-    ) : TransactionTranslator {
-        override fun VirtualFile.translate(): VirtualFile? =
-            clonedProjectDir.findFileByRelativePath(toNioPath().relativeTo(originalPath).pathString)
     }
 }

--- a/project-minimization-plugin/src/test/kotlin/FileLevelStageTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/FileLevelStageTest.kt
@@ -1,0 +1,80 @@
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.runWithModalProgressBlocking
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
+import org.plan.research.minimization.plugin.execution.DumbCompiler
+import org.plan.research.minimization.plugin.model.FileLevelStage
+import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.model.state.CompilationStrategy
+import org.plan.research.minimization.plugin.model.state.DDStrategy
+import org.plan.research.minimization.plugin.model.state.HierarchyCollectionStrategy
+import org.plan.research.minimization.plugin.services.MinimizationStageExecutorService
+import org.plan.research.minimization.plugin.services.ProjectCloningService
+import org.plan.research.minimization.plugin.settings.MinimizationPluginSettings
+
+class FileLevelStageTest : JavaCodeInsightFixtureTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/resources/testData/fileTreeHierarchy"
+    }
+
+    override fun setUp() {
+        super.setUp()
+        project.service<MinimizationPluginSettings>().state.currentCompilationStrategy = CompilationStrategy.DUMB
+    }
+
+    fun testFullProject() {
+        val root = myFixture.copyDirectoryToProject("complicated-project", "")
+        minimizeProjectTest(root, null)
+    }
+
+    fun testOneTargetFileProject() {
+        val root = myFixture.copyDirectoryToProject("complicated-project", "")
+        minimizeProjectTest(
+            root, listOf(
+                "0/1/2/3/4/5/6/7/8/9/10.txt",
+            )
+        )
+    }
+
+    fun testPartialProject() {
+        val root = myFixture.copyDirectoryToProject("complicated-project", "")
+        minimizeProjectTest(
+            root, listOf(
+                "0/1.txt",
+                "0/1/2/3/4/5.txt",
+                "0/1/2/3/4/5/6.txt",
+            )
+        )
+    }
+
+    private fun minimizeProjectTest(root: VirtualFile, targetPaths: List<String>?) {
+        DumbCompiler.targetPaths = targetPaths
+        val project = myFixture.project
+        val executor = project.service<MinimizationStageExecutorService>()
+        val stage = FileLevelStage(
+            HierarchyCollectionStrategy.FILE_TREE,
+            DDStrategy.PROBABILISTIC_DD
+        )
+
+        val targetFiles = if (targetPaths == null) {
+            project.getAllFiles()
+        } else {
+            targetPaths.map { root.findFileByRelativePath(it)!! }
+                .getAllFiles(project) + root.getPathContentPair(project)
+        }
+
+        val minimizedProject = runWithModalProgressBlocking(project, "") {
+            val clonedProject = project.service<ProjectCloningService>().clone(project)!!
+            stage.apply(IJDDContext(clonedProject, project), executor)
+        }.getOrNull()?.project
+        assertNotNull(minimizedProject)
+
+        val minimizedFiles = minimizedProject!!.getAllFiles()
+        assertEquals(targetFiles, minimizedFiles)
+
+        ProjectManager.getInstance().closeAndDispose(minimizedProject)
+
+        DumbCompiler.targetPaths = null // it's important
+    }
+}

--- a/project-minimization-plugin/src/test/kotlin/FileTreeHierarchyGeneratorTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/FileTreeHierarchyGeneratorTest.kt
@@ -16,7 +16,7 @@ import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithmResult
 import org.plan.research.minimization.plugin.hierarchy.FileTreeHierarchicalDDGenerator
 import org.plan.research.minimization.plugin.hierarchy.FileTreeHierarchyGenerator
-import org.plan.research.minimization.plugin.model.CompilationStrategy
+import org.plan.research.minimization.plugin.model.state.CompilationStrategy
 import org.plan.research.minimization.plugin.settings.MinimizationPluginSettings
 import kotlin.test.assertIs
 

--- a/project-minimization-plugin/src/test/kotlin/FileTreeHierarchyGeneratorTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/FileTreeHierarchyGeneratorTest.kt
@@ -49,7 +49,6 @@ class FileTreeHierarchyGeneratorTest : JavaCodeInsightFixtureTestCase() {
                 )
             )
         })
-        generator.clear()
     }
 
     fun testSingleFileProject() {
@@ -86,7 +85,6 @@ class FileTreeHierarchyGeneratorTest : JavaCodeInsightFixtureTestCase() {
                 )
             )
         })
-        generator.clear()
     }
 
     fun testComplicatedFileStructure() {
@@ -159,7 +157,6 @@ class FileTreeHierarchyGeneratorTest : JavaCodeInsightFixtureTestCase() {
                 )
             )
         })
-        generator.clear()
     }
 
     private fun getPsiDepth(element: PsiElement?): Int = if (element == null) 0 else getPsiDepth(element.parent) + 1
@@ -168,16 +165,5 @@ class FileTreeHierarchyGeneratorTest : JavaCodeInsightFixtureTestCase() {
         assertIs<Either.Right<FileTreeHierarchicalDDGenerator>>(ddGenerator)
         val generator = ddGenerator.value
         return generator
-    }
-
-    private fun FileTreeHierarchicalDDGenerator.clear() {
-        this
-            .getAllLevels()
-            .filter { it.context.project.name != myFixture.project.name }
-            .map { it.context.project }
-            .toSet()
-            .forEach {
-                ProjectManager.getInstance().closeAndDispose(it)
-            }
     }
 }

--- a/project-minimization-plugin/src/test/kotlin/ProjectCloningBaseTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/ProjectCloningBaseTest.kt
@@ -1,0 +1,44 @@
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.isFile
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
+import org.plan.research.minimization.plugin.getAllParents
+import java.nio.file.Path
+import kotlin.io.path.relativeTo
+
+abstract class ProjectCloningBaseTest : JavaCodeInsightFixtureTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/resources/testData/projectCloning"
+    }
+
+    protected fun VirtualFile.getPathContentPair(project: Project): Pair<Path, String?> =
+        toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath()) to
+                this.takeIf { it.isFile }?.contentsToByteArray()?.toString(Charsets.UTF_8)
+
+    protected fun Project.getAllFiles(): Set<Pair<Path, String?>> {
+        return buildSet {
+            val index = ProjectRootManager.getInstance(this@getAllFiles).fileIndex
+            index.iterateContent {
+                add(it.getPathContentPair(this@getAllFiles))
+            }
+        }
+    }
+
+    protected fun VirtualFile.getAllFiles(project: Project): Set<Pair<Path, String?>> = buildSet {
+        add(getPathContentPair(project))
+        if (isFile)
+            return@buildSet
+        children.forEach {
+            addAll(it.getAllFiles(project))
+        }
+    }
+
+    protected fun List<VirtualFile>.getAllFiles(project: Project): Set<Pair<Path, String?>> =
+        flatMap { it.getAllFiles(project) }.toSet() + getAllParents(project.guessProjectDir()!!).map {
+            it.getPathContentPair(
+                project
+            )
+        }.toSet()
+}

--- a/project-minimization-plugin/src/test/kotlin/ProjectCloningBaseTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/ProjectCloningBaseTest.kt
@@ -1,44 +1,7 @@
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.isFile
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
-import org.plan.research.minimization.plugin.getAllParents
-import java.nio.file.Path
-import kotlin.io.path.relativeTo
 
 abstract class ProjectCloningBaseTest : JavaCodeInsightFixtureTestCase() {
     override fun getTestDataPath(): String {
         return "src/test/resources/testData/projectCloning"
     }
-
-    protected fun VirtualFile.getPathContentPair(project: Project): Pair<Path, String?> =
-        toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath()) to
-                this.takeIf { it.isFile }?.contentsToByteArray()?.toString(Charsets.UTF_8)
-
-    protected fun Project.getAllFiles(): Set<Pair<Path, String?>> {
-        return buildSet {
-            val index = ProjectRootManager.getInstance(this@getAllFiles).fileIndex
-            index.iterateContent {
-                add(it.getPathContentPair(this@getAllFiles))
-            }
-        }
-    }
-
-    protected fun VirtualFile.getAllFiles(project: Project): Set<Pair<Path, String?>> = buildSet {
-        add(getPathContentPair(project))
-        if (isFile)
-            return@buildSet
-        children.forEach {
-            addAll(it.getAllFiles(project))
-        }
-    }
-
-    protected fun List<VirtualFile>.getAllFiles(project: Project): Set<Pair<Path, String?>> =
-        flatMap { it.getAllFiles(project) }.toSet() + getAllParents(project.guessProjectDir()!!).map {
-            it.getPathContentPair(
-                project
-            )
-        }.toSet()
 }

--- a/project-minimization-plugin/src/test/kotlin/ProjectCloningSnapshotTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/ProjectCloningSnapshotTest.kt
@@ -1,0 +1,129 @@
+import com.intellij.openapi.application.writeAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.runWithModalProgressBlocking
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.utils.vfs.deleteRecursively
+import org.plan.research.minimization.plugin.errors.SnapshotError
+import org.plan.research.minimization.plugin.getAllNestedElements
+import org.plan.research.minimization.plugin.model.IJDDContext
+import org.plan.research.minimization.plugin.services.ProjectCloningService
+import org.plan.research.minimization.plugin.snapshot.ProjectCloningSnapshotManager
+import kotlin.io.path.Path
+import kotlin.io.path.relativeTo
+
+class ProjectCloningSnapshotTest : ProjectCloningBaseTest() {
+    fun testOneFileProjectPartialCloning() {
+        val file = myFixture.configureByFile("oneFileProject.txt")
+        doPartialCloningTest(
+            listOf(
+                file.virtualFile
+            )
+        )
+        doPartialCloningTest(listOf())
+    }
+
+    fun testFlatProjectPartialCloning() {
+        val root = myFixture.copyDirectoryToProject("flatProject", "")
+        val fileMap = root.children.associateBy { it.name }
+        doPartialCloningTest(root.getAllNestedElements())
+        doPartialCloningTest(listOf(fileMap[".config"], fileMap["A"], fileMap["B"]).map { it!! })
+        doPartialCloningTest(listOf(fileMap[".config"]!!))
+    }
+
+    fun testTreeProjectPartialCloning() {
+        val root = myFixture.copyDirectoryToProject("treeProject", "")
+        val fileMap = buildMap {
+            VfsUtilCore.iterateChildrenRecursively(root, null) {
+                this[it.toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath())] = it
+                true
+            }
+        }
+        doPartialCloningTest(listOf(root))
+        doPartialCloningTest(listOf(fileMap[Path("root-file")]!!))
+        doPartialCloningTest(listOf(fileMap[Path("depth-1-a", "depth-2-a", "depth-2-file-a-a")]!!))
+        doPartialCloningTest(
+            listOf(
+                fileMap[Path("depth-1-a", "depth-2-a", "pretty-good-file")]!!,
+                fileMap[Path("depth-1-a", "depth-2-a-prime", "pretty-good-file")]!!,
+                fileMap[Path("depth-1-a", "pretty-good-file")]!!,
+                fileMap[Path("depth-1-b", "pretty-good-file")]!!,
+                fileMap[Path("depth-1-b", "depth-2-b", "pretty-good-file")]!!,
+                fileMap[Path("depth-1-b", "depth-2-b-prime", "pretty-good-file")]!!,
+            )
+        )
+    }
+
+    private fun doPartialCloningTest(
+        selectedFiles: List<VirtualFile>
+    ) {
+        val project = myFixture.project
+        val snapshotManager = ProjectCloningSnapshotManager(project)
+        val projectCloning = project.service<ProjectCloningService>()
+
+        val originalFiles =
+            selectedFiles.getAllFiles(project) + project.guessProjectDir()!!.getPathContentPair(project)
+
+        val clonedProject = runWithModalProgressBlocking(project, "") {
+            val context = IJDDContext(projectCloning.clone(project)!!)
+            snapshotManager.transaction<Unit>(context) { newContext ->
+                writeAction {
+                    VfsUtil.iterateChildrenRecursively(newContext.project.guessProjectDir()!!, null) {
+                        if (it.getPathContentPair(newContext.project) !in originalFiles) {
+                            if (it.exists()) {
+                                it.deleteRecursively()
+                            }
+                        }
+                        true
+                    }
+                }
+                newContext
+            }
+        }.getOrNull()?.project
+        assertNotNull(clonedProject)
+        val clonedFiles = clonedProject!!.getAllFiles()
+        assertEquals(originalFiles, clonedFiles)
+        ProjectManager.getInstance().closeAndDispose(clonedProject)
+    }
+
+    fun testAbortedTransaction() {
+        myFixture.copyDirectoryToProject("flatProject", "")
+        val project = myFixture.project
+
+        val snapshotManager = ProjectCloningSnapshotManager(project)
+        val result = runWithModalProgressBlocking(project, "") {
+            snapshotManager.transaction(IJDDContext(project)) { newProject ->
+                writeAction {
+                    newProject.project.guessProjectDir()!!.findChild(".config")!!.deleteRecursively()
+                }
+                raise("Abort")
+            }
+        }.leftOrNull()
+
+        assertEquals(SnapshotError.Aborted("Abort"), result)
+        assertNotNull(project.guessProjectDir()!!.findChild(".config"))
+        assert(project.isOpen)
+    }
+
+    fun testExceptionInTransaction() {
+        myFixture.copyDirectoryToProject("flatProject", "")
+        val project = myFixture.project
+
+        val snapshotManager = ProjectCloningSnapshotManager(project)
+        val result = runWithModalProgressBlocking(project, "") {
+            snapshotManager.transaction<String>(IJDDContext(project)) { newProject ->
+                writeAction {
+                    newProject.project.guessProjectDir()!!.findChild(".config")!!.deleteRecursively()
+                }
+                throw Exception("Abort")
+            }
+        }.leftOrNull()
+
+        assertEquals("Abort", (result as? SnapshotError.TransactionFailed)?.error?.message)
+        assertNotNull(project.guessProjectDir()!!.findChild(".config"))
+        assert(project.isOpen)
+    }
+}

--- a/project-minimization-plugin/src/test/kotlin/ProjectCloningTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/ProjectCloningTest.kt
@@ -3,7 +3,6 @@ import com.intellij.openapi.progress.runWithModalProgressBlocking
 import com.intellij.openapi.project.ProjectManager
 import org.junit.Assert.assertNotEquals
 import org.plan.research.minimization.plugin.services.ProjectCloningService
-import java.nio.file.Path
 
 class ProjectCloningTest : ProjectCloningBaseTest() {
     fun testOneFileProject() {
@@ -46,7 +45,7 @@ class ProjectCloningTest : ProjectCloningBaseTest() {
         doFullCloningOfClonedTest()
     }
 
-    private fun doFullCloningTest(originalFileSet: Set<Pair<Path, String?>>? = null): Set<Pair<Path, String?>> {
+    private fun doFullCloningTest(originalFileSet: Set<PathContent>? = null): Set<PathContent> {
         val project = myFixture.project
         val files = originalFileSet ?: project.getAllFiles()
         val projectCloningService = project.service<ProjectCloningService>()
@@ -58,7 +57,7 @@ class ProjectCloningTest : ProjectCloningBaseTest() {
         return files
     }
 
-    private fun doFullCloningOfClonedTest(originalFileSet: Set<Pair<Path, String?>>? = null): Set<Pair<Path, String?>> {
+    private fun doFullCloningOfClonedTest(originalFileSet: Set<PathContent>? = null): Set<PathContent> {
         val project = myFixture.project
         val files = originalFileSet ?: project.getAllFiles()
         val projectCloningService = project.service<ProjectCloningService>()

--- a/project-minimization-plugin/src/test/kotlin/ProjectCloningTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/ProjectCloningTest.kt
@@ -1,25 +1,11 @@
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.runWithModalProgressBlocking
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.isFile
-import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
-import org.plan.research.minimization.plugin.getAllNestedElements
-import org.plan.research.minimization.plugin.getAllParents
+import org.junit.Assert.assertNotEquals
 import org.plan.research.minimization.plugin.services.ProjectCloningService
 import java.nio.file.Path
-import kotlin.io.path.Path
-import kotlin.io.path.relativeTo
 
-class ProjectCloningTest : JavaCodeInsightFixtureTestCase() {
-    override fun getTestDataPath(): String {
-        return "src/test/resources/testData/projectCloning"
-    }
-
+class ProjectCloningTest : ProjectCloningBaseTest() {
     fun testOneFileProject() {
         myFixture.configureByFile("oneFileProject.txt")
         doFullCloningTest()
@@ -60,73 +46,14 @@ class ProjectCloningTest : JavaCodeInsightFixtureTestCase() {
         doFullCloningOfClonedTest()
     }
 
-    fun testOneFileProjectPartialCloning() {
-        val file = myFixture.configureByFile("oneFileProject.txt")
-        doPartialCloningTest(
-            listOf(
-                file.virtualFile
-            )
-        )
-        doPartialCloningTest(listOf())
-    }
-
-    fun testFlatProjectPartialCloning() {
-        val root = myFixture.copyDirectoryToProject("flatProject", "")
-        val fileMap = root.children.associateBy { it.name }
-        doPartialCloningTest(root.getAllNestedElements())
-        doPartialCloningTest(listOf(fileMap[".config"], fileMap["A"], fileMap["B"]).map { it!! })
-        doPartialCloningTest(listOf(fileMap[".config"]!!))
-    }
-
-    fun testTreeProjectPartialCloning() {
-        val root = myFixture.copyDirectoryToProject("treeProject", "")
-        val fileMap = buildMap {
-            VfsUtilCore.iterateChildrenRecursively(root, null) {
-                this[it.toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath())] = it
-                true
-            }
-        }
-        doPartialCloningTest(listOf(root))
-        doPartialCloningTest(listOf(fileMap[Path("root-file")]!!))
-        doPartialCloningTest(listOf(fileMap[Path("depth-1-a", "depth-2-a", "depth-2-file-a-a")]!!))
-        doPartialCloningTest(
-            listOf(
-                fileMap[Path("depth-1-a", "depth-2-a", "pretty-good-file")]!!,
-                fileMap[Path("depth-1-a", "depth-2-a-prime", "pretty-good-file")]!!,
-                fileMap[Path("depth-1-a", "pretty-good-file")]!!,
-                fileMap[Path("depth-1-b", "pretty-good-file")]!!,
-                fileMap[Path("depth-1-b", "depth-2-b", "pretty-good-file")]!!,
-                fileMap[Path("depth-1-b", "depth-2-b-prime", "pretty-good-file")]!!,
-            )
-        )
-    }
-
-    private fun doPartialCloningTest(
-        selectedFiles: List<VirtualFile>
-    ) {
-        val project = myFixture.project
-        val projectCloningService = project.service<ProjectCloningService>()
-
-        val originalFiles =
-            selectedFiles.getAllFiles(project) + setOf(project.guessProjectDir()!!.getPathContentPair(project))
-
-        val clonedProject = runWithModalProgressBlocking(project, "") {
-            projectCloningService.clone(project, selectedFiles)
-        }
-        kotlin.test.assertNotNull(clonedProject)
-        val clonedFiles = clonedProject.getAllFiles()
-        kotlin.test.assertEquals(originalFiles, clonedFiles)
-        ProjectManager.getInstance().closeAndDispose(clonedProject)
-    }
-
     private fun doFullCloningTest(originalFileSet: Set<Pair<Path, String?>>? = null): Set<Pair<Path, String?>> {
         val project = myFixture.project
         val files = originalFileSet ?: project.getAllFiles()
         val projectCloningService = project.service<ProjectCloningService>()
         val clonedProject = runWithModalProgressBlocking(project, "") { projectCloningService.clone(project) }
-        kotlin.test.assertNotNull(clonedProject)
-        val clonedFiles = clonedProject.getAllFiles()
-        kotlin.test.assertEquals(files, clonedFiles)
+        assertNotNull(clonedProject)
+        val clonedFiles = clonedProject!!.getAllFiles()
+        assertEquals(files, clonedFiles)
         ProjectManager.getInstance().closeAndDispose(clonedProject)
         return files
     }
@@ -136,45 +63,19 @@ class ProjectCloningTest : JavaCodeInsightFixtureTestCase() {
         val files = originalFileSet ?: project.getAllFiles()
         val projectCloningService = project.service<ProjectCloningService>()
         val clonedProject = runWithModalProgressBlocking(project, "") { projectCloningService.clone(project) }
-        kotlin.test.assertNotNull(clonedProject)
-        val clonedFiles = clonedProject.getAllFiles()
-        kotlin.test.assertEquals(files, clonedFiles)
+        assertNotNull(clonedProject)
+        val clonedFiles = clonedProject!!.getAllFiles()
+        assertEquals(files, clonedFiles)
 
         val clonedClonedProject =
             runWithModalProgressBlocking(project, "") { projectCloningService.clone(clonedProject) }
-        kotlin.test.assertNotNull(clonedClonedProject)
-        val clonedClonedFiles = clonedClonedProject.getAllFiles()
-        kotlin.test.assertEquals(files, clonedClonedFiles)
-        kotlin.test.assertNotEquals(clonedProject, clonedClonedProject)
+        assertNotNull(clonedClonedProject)
+        val clonedClonedFiles = clonedClonedProject!!.getAllFiles()
+        assertEquals(files, clonedClonedFiles)
+        assertNotEquals(clonedProject, clonedClonedProject)
 
         ProjectManager.getInstance().closeAndDispose(clonedClonedProject)
         ProjectManager.getInstance().closeAndDispose(clonedProject)
         return files
     }
-
-    private fun VirtualFile.getPathContentPair(project: Project): Pair<Path, String?> =
-        toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath()) to
-                this.takeIf { it.isFile }?.contentsToByteArray()?.toString(Charsets.UTF_8)
-
-    private fun Project.getAllFiles(): Set<Pair<Path, String?>> {
-        return buildSet {
-            val index = ProjectRootManager.getInstance(this@getAllFiles).fileIndex
-            index.iterateContent {
-                add(it.getPathContentPair(this@getAllFiles))
-            }
-        }
-    }
-
-    private fun VirtualFile.getAllFiles(project: Project): Set<Pair<Path, String?>> = buildSet {
-        add(getPathContentPair(project))
-        if (isFile)
-            return@buildSet
-        children.forEach {
-            addAll(it.getAllFiles(project))
-        }
-    }
-
-    private fun List<VirtualFile>.getAllFiles(project: Project): Set<Pair<Path, String?>> =
-        flatMap { it.getAllFiles(project) }.toSet() + getAllParents(project.guessProjectDir()!!).map { it.getPathContentPair(project) }.toSet()
 }
-

--- a/project-minimization-plugin/src/test/kotlin/Util.kt
+++ b/project-minimization-plugin/src/test/kotlin/Util.kt
@@ -1,0 +1,41 @@
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.isFile
+import org.plan.research.minimization.plugin.getAllParents
+import java.nio.file.Path
+import kotlin.io.path.relativeTo
+
+data class PathContent(val path: Path, val content: String?)
+
+infix fun Path.to(content: String?) = PathContent(this, content)
+
+fun VirtualFile.getPathContentPair(project: Project): PathContent =
+    toNioPath().relativeTo(project.guessProjectDir()!!.toNioPath()) to
+            this.takeIf { it.isFile }?.contentsToByteArray()?.toString(Charsets.UTF_8)
+
+fun Project.getAllFiles(): Set<PathContent> {
+    return buildSet {
+        val index = ProjectRootManager.getInstance(this@getAllFiles).fileIndex
+        index.iterateContent {
+            add(it.getPathContentPair(this@getAllFiles))
+        }
+    }
+}
+
+fun VirtualFile.getAllFiles(project: Project): Set<PathContent> = buildSet {
+    add(getPathContentPair(project))
+    if (isFile)
+        return@buildSet
+    children.forEach {
+        addAll(it.getAllFiles(project))
+    }
+}
+
+fun List<VirtualFile>.getAllFiles(project: Project): Set<PathContent> =
+    flatMap { it.getAllFiles(project) }.toSet() + getAllParents(project.guessProjectDir()!!).map {
+        it.getPathContentPair(
+            project
+        )
+    }.toSet()


### PR DESCRIPTION
Here are the main changes:
- HDD levels are optional now, even the first one
- `ProjectCloningService` still exists because it's useful anyway
- There are `SnapshotManager`s with only one method -- `transaction`
- Also representation of VirtualFileDDItem changed to make it independent of any project