### PR TITLE
JBRes-2119 Fix Exception Parsing

### DIFF
--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/SameExceptionPropertyTester.kt
@@ -13,6 +13,7 @@ import arrow.core.getOrElse
 import arrow.core.raise.option
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import mu.KotlinLogging
 
 /**
  * A property tester for Delta Debugging algorithm that leverages different compilation strategies
@@ -24,6 +25,7 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
     private val lens: ProjectItemLens,
     private val initialException: CompilationException,
 ) : PropertyTester<IJDDContext, T> {
+    private val logger = KotlinLogging.logger {}
     private val snapshotManager = rootProject.service<SnapshotManagerService>()
 
     /**
@@ -69,7 +71,7 @@ class SameExceptionPropertyTester<T : IJDDItem> private constructor(
                 exceptionComparator,
                 lens,
                 initialException,
-            )
+            ).also { it.logger.debug { "Initial exception is $initialException" } }
         }
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/exception/KotlincException.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/exception/KotlincException.kt
@@ -62,4 +62,14 @@ sealed interface KotlincException : CompilationException {
             context: IJDDContext,
         ) = transformation.transform(this, context)
     }
+    data class KspException(
+        val message: String,
+        val stacktrace: String,
+        val severity: KotlincErrorSeverity = KotlincErrorSeverity.UNKNOWN,
+    ) : KotlincException {
+        override suspend fun apply(
+            transformation: ExceptionTransformation,
+            context: IJDDContext,
+        ) = transformation.transform(this, context)
+    }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/exception/KotlincExceptionTranslator.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/exception/KotlincExceptionTranslator.kt
@@ -38,6 +38,9 @@ class KotlincExceptionTranslator : BuildEventTranslator {
         }
 
     private fun transformCompilationError(buildEvent: BuildEvent) = either {
+        if (buildEvent.message.startsWith("[ksp]")) {
+            return@either parseKspError(buildEvent).bind()
+        }
         ensure(buildEvent is FileMessageEvent) {
             raise(
                 CompilationPropertyCheckerError.BuildSystemFail(
@@ -51,13 +54,26 @@ class KotlincExceptionTranslator : BuildEventTranslator {
         KotlincException.GeneralKotlincException(filePosition, buildEvent.message, buildEvent.severity())
     }
 
+    private fun parseKspError(event: BuildEvent) = either {
+        val messageWithoutKsp = event.message.removePrefix("[ksp] ")
+        val (additionalMessage, stacktrace) = messageWithoutKsp.splitMessageAndStacktrace()
+            .getOrElse { raise(CompilationPropertyCheckerError.CompilationSuccess) }
+        KotlincException.KspException(
+            additionalMessage,
+            stacktrace,
+            (event as? MessageEvent)?.severity() ?: KotlincErrorSeverity.UNKNOWN,
+        )
+    }
+
     private fun parseInternalException(
         buildEvent: BuildEvent,
     ): Either<CompilationPropertyCheckerError, KotlincException> = either {
         val (exceptionType, exceptionMessage) = parseExceptionMessage(buildEvent.description ?: "")
             ?: raise(CompilationPropertyCheckerError.CompilationSuccess)
         when (exceptionType) {
-            BACKEND_COMPILER_EXCEPTION_CLASSNAME -> parseBackendCompilerException(exceptionMessage).bind()
+            BACKEND_COMPILER_EXCEPTION_CLASSNAME, COMMON_BACKEND_EXCEPTION_CLASSNAME ->
+                parseBackendCompilerException(exceptionMessage).bind()
+
             else -> parseGenericInternalCompilerException(exceptionMessage).bind()
         }
     }
@@ -94,7 +110,9 @@ class KotlincExceptionTranslator : BuildEventTranslator {
     private fun BuildEvent.isInternal(): Boolean =
         // FIXME: Not sure that is complete way to check if the exception is internal
         message.endsWith("Please report this problem https://kotl.in/issue") ||
-            message.startsWith("org.jetbrains.kotlin.util.FileAnalysisException")
+            message.startsWith("org.jetbrains.kotlin.util.FileAnalysisException") ||
+            message.startsWith(BACKEND_COMPILER_EXCEPTION_CLASSNAME) ||
+            message.startsWith(COMMON_BACKEND_EXCEPTION_CLASSNAME)
 
     private fun parseExceptionMessage(message: String): Pair<String, String>? {
         val colonIndex = message.indexOfOrNull(COLON) ?: return null
@@ -128,5 +146,8 @@ class KotlincExceptionTranslator : BuildEventTranslator {
         private const val BACKEND_COMPILER_EXCEPTION_CLASSNAME =
             "org.jetbrains.kotlin.backend.common.CompilationException"
         private const val COLON = ':'
+
+        private const val COMMON_BACKEND_EXCEPTION_CLASSNAME =
+            "org.jetbrains.kotlin.backend.common.BackendException"  // old version, I suppose
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/transformer/PathRelativizationTransformation.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/execution/transformer/PathRelativizationTransformation.kt
@@ -54,6 +54,9 @@ class PathRelativizationTransformation : ExceptionTransformation {
         )
     }
 
+    override suspend fun transform(exception: KspException, context: IJDDContext): KspException =
+        exception.copy(message = exception.message.replaceRootDir(context))
+
     private fun transformPath(path: Path, context: IJDDContext): Path {
         val projectBase = context.project.guessProjectDir()?.toNioPathOrNull() ?: return path
         return path.relativeTo(projectBase)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/CaretPosition.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/CaretPosition.kt
@@ -16,9 +16,19 @@ data class CaretPosition(val filePath: Path, val lineNumber: Int, val columnNumb
             lineNumber = from.startLine,
             columnNumber = from.startColumn,
         )
+
         fun fromString(from: String): CaretPosition {
+            if (isOldFileFormatString(from)) {
+                return CaretPosition(
+                    filePath = Path.of(from.removePrefix("File being compiled: ")),
+                    lineNumber = -1,
+                    columnNumber = -1,
+                )
+            }
             val (filePath, line, column) = from.split(":")  // In general paths with ":" will break it. But why should we care now?
             return CaretPosition(Path.of(filePath), line.toInt(), column.toInt())
         }
+
+        private fun isOldFileFormatString(string: String) = string.startsWith("File being compiled:")
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/exception/ExceptionTransformation.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/exception/ExceptionTransformation.kt
@@ -19,4 +19,6 @@ interface ExceptionTransformation {
 
     suspend fun transform(exception: BackendCompilerException, context: IJDDContext): BackendCompilerException =
         exception
+
+    suspend fun transform(exception: KspException, context: IJDDContext) = exception
 }

--- a/project-minimization-plugin/src/test/kotlin/KotlincExceptionTranslatorTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/KotlincExceptionTranslatorTest.kt
@@ -134,6 +134,45 @@ class KotlincExceptionTranslatorTest : JavaCodeInsightFixtureTestCase() {
             translated2.message
         )
         assert(translated2.stacktrace.lines().all { it.startsWith("\tat ") })
+
+        val oldBackendError = MockBuildEvent(
+            "org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering",
+            "org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering\n" +
+                    "File being compiled: /Users/Sergei.Kharitontcev-Beglov/Work/minimization/dataset/projects/kaliningraph/src/commonTest/kotlin/ai/hypergraph/kaliningraph/types/BinaryTest.kt\n" +
+                    "The root cause java.lang.RuntimeException was thrown at: org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:50)\n" +
+                    "\tat org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:239)\n" +
+                    "\tat org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException\$default(CodegenUtil.kt:235)\n" +
+                    "\tat <REDACTED>\n" +
+                    "Caused by: java.lang.RuntimeException: Exception while generating code for:\n" +
+                    "FUN name:binaryTest visibility:public modality:FINAL <> (\$this:ai.hypergraph.kaliningraph.types.BinaryTest) returnType:kotlin.Unit\n" +
+                    "  annotations:\n" +
+                    "    Test\n" +
+                    "  \$this: VALUE_PARAMETER name:<this> type:ai.hypergraph.kaliningraph.types.BinaryTest\n" +
+                    "  BLOCK_BODY\n" +
+                    "    VAR name:fifteen type:kotlin.Int [val]\n" +
+                    "      CALL 'public final fun toInt\$default (i: kotlin.Int, j: kotlin.Int, \$mask0: kotlin.Int, \$handler: kotlin.Any?): kotlin.Int declared in ai.hypergraph.kaliningraph.types.BinaryKt' type=kotlin.Int origin=DEFAULT_DISPATCH_CALL\n" +
+                    "        \$receiver: CALL 'public final fun plus1 <B> (): ai.hypergraph.kaliningraph.types.T<B of ai.hypergraph.kaliningraph.types.BinaryKt.plus1> declared in ai.hypergraph.kaliningraph.types.BinaryKt' type=ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<kotlin.Nothing>>>> origin=null\n" +
+                    "          <B>: ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<kotlin.Nothing>>>\n" +
+                    "          \$receiver: CALL 'public final fun plus1 <B> (): ai.hypergraph.kaliningraph.types.F<ai.hypergraph.kaliningraph.types.T<B of ai.hypergraph.kaliningraph.types.BinaryKt.plus1>> declared in ai.hypergraph.kaliningraph.types.BinaryKt' type=ai.hypergraph.kaliningraph.types.F<ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<kotlin.Nothing>>>> origin=null\n" +
+                    "            <B>: ai.hypergraph.kaliningraph.types.T<ai.hypergraph.kaliningraph.types.T<kotlin.Nothing>>\n" +
+                    "<REDACTED>" +
+                    "\n" +
+                    "\tat org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:50)\n" +
+                    "\tat org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate\$default(FunctionCodegen.kt:43)\n" +
+                    "\t... 44 more\n" +
+                    "Caused by: java.lang.IndexOutOfBoundsException: Empty list doesn't contain element at index 0.\n" +
+                    "\tat kotlin.collections.EmptyList.get(Collections.kt:36)\n" +
+                    "\tat kotlin.collections.EmptyList.get(Collections.kt:24)\n" +
+                    "\t... 53 more\n" +
+                    "\n" ,
+            Kind.ERROR
+        )
+        val translated3 = translator.parseException(oldBackendError).getOrNull()
+        kotlin.test.assertNotNull(translated3)
+        assertIs<KotlincException.BackendCompilerException>(translated3)
+        // TODO: fix this when will be doing JBRes-1899
+//        assert(translated3.stacktrace.lines().all { it.startsWith("\tat ") })
+
     }
 
     fun testInvalidException() {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/JBRes-2119/Fix-Exception-Parsing

## Description

Fixed the internal exception parsing for the old versions (≈1.6.20–1.7.0) of Kotlin Compiler. Additionally, added support for KSP exceptions.

## How to test

### Automated tests

`KotlincExceptionTranslatorTest` was modified to test old backend exception. No tests for KSP, though, since we are not focusing on it at this time.

### Manual tests

The main reasons of this pull request to make `kaliningraph` working. So, you now can test `kaliningraph` and it should reproduce its behavior.

## Self-check list

- [x] PR **title** and **description** are clear and aligned with a format.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas. 
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided _optionally_.
- [x] The **documentation** for the functionality I've been working on is up-to-date/provided.
- [x] The **link** to this PR is commented on in the corresponding **YT ticket**.

Hint: [x] is a marked item
