### PR TITLE
[JBRes-2910] Primary constructor parameters deletion

### DIFF
--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/lenses/BasePsiLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/lenses/BasePsiLens.kt
@@ -45,7 +45,7 @@ abstract class BasePsiLens<C, I, T> :
     protected open fun transformSelectedElements(item: I, context: C): List<I> = listOf(item)
 
     context(IJDDContextMonad<C>)
-    protected open fun prepare(itemsToDelete: List<I>) = Unit
+    protected open suspend fun prepare(itemsToDelete: List<I>) = Unit
 
     private suspend fun logFocusedItems(items: List<I>, context: C) {
         if (!logger.isTraceEnabled) {

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/lenses/FunctionDeletingLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/lenses/FunctionDeletingLens.kt
@@ -67,12 +67,12 @@ class FunctionDeletingLens<C : WithImportRefCounterContext<C>> : BasePsiLens<C, 
         element.delete()
     }
 
-    context(IJDDContextMonad<C>)
     private suspend fun deleteImportInTraces(
         refCounter: PsiImportRefCounter,
         call: PsiStubChildrenCompositionItem,
         indexToDelete: Int,
         originalFile: KtFile,
+        context: C,
     ) = refCounter.run {
         logger.trace { "Deleting imports in  call=${call.childrenPath} (in file=${call.localPath})" }
         val callExpression = readAction {
@@ -134,6 +134,7 @@ class FunctionDeletingLens<C : WithImportRefCounterContext<C>> : BasePsiLens<C, 
                     item,
                     index,
                     originalFile,
+                    context,
                 )
             }
         }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/MinimizationStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/MinimizationStage.kt
@@ -107,6 +107,7 @@ data class DeclarationLevelStage(
 @optics
 data class DeclarationGraphStage(
     @Property val ddAlgorithm: DDStrategy = DDStrategy.PROBABILISTIC_DD,
+    @Property val isFunctionParametersEnabled: Boolean = true,
 ) : MinimizationStage {
     override val name: String = "Declaration Graph Minimization"
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/item/PsiStubDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/item/PsiStubDDItem.kt
@@ -24,6 +24,7 @@ sealed interface PsiStubDDItem : PsiDDItem<KtStub> {
                 KtProperty::class.java,
             )
     }
+
     data class NonOverriddenPsiStubDDItem(
         override val localPath: Path,
         override val childrenPath: List<KtStub>,
@@ -45,11 +46,14 @@ sealed interface PsiStubDDItem : PsiDDItem<KtStub> {
         val callTraces: List<PsiStubChildrenCompositionItem>,
     ) : PsiStubDDItem {
         companion object {
-            fun create(from: PsiStubDDItem, traces: List<PsiStubChildrenCompositionItem>) = CallablePsiStubDDItem(
+            fun create(
+                from: PsiStubDDItem,
+                traces: List<PsiStubChildrenCompositionItem>,
+            ) = CallablePsiStubDDItem(
                 from.childrenElements,
                 from.localPath,
                 from.childrenPath,
-                traces,
+                traces.distinct(),
             )
         }
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/item/PsiStubDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/model/item/PsiStubDDItem.kt
@@ -43,5 +43,14 @@ sealed interface PsiStubDDItem : PsiDDItem<KtStub> {
         override val localPath: Path,
         override val childrenPath: List<KtStub>,
         val callTraces: List<PsiStubChildrenCompositionItem>,
-    ) : PsiStubDDItem
+    ) : PsiStubDDItem {
+        companion object {
+            fun create(from: PsiStubDDItem, traces: List<PsiStubChildrenCompositionItem>) = CallablePsiStubDDItem(
+                from.childrenElements,
+                from.localPath,
+                from.childrenPath,
+                traces,
+            )
+        }
+    }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/KotlinOverriddenElementsGetter.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/KotlinOverriddenElementsGetter.kt
@@ -15,7 +15,7 @@ object KotlinOverriddenElementsGetter {
         is KtNamedFunction -> getOverriddenFunction(element)
         is KtProperty -> getOverriddenProperties(element)
         is KtClass -> getOverriddenClass(element).takeIf { includeClass }
-            .orEmpty() + getOverriddenConstructorParameters(element)
+            .orEmpty()
 
         is KtParameter -> getOverriddenParameters(element)
         else -> emptyList()
@@ -53,8 +53,4 @@ object KotlinOverriddenElementsGetter {
             ?.toList()
             ?: emptyList()
     }
-
-    private fun getOverriddenConstructorParameters(klass: KtClass) = klass
-        .primaryConstructorParameters
-        .flatMap(::getOverriddenParameters)
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/PsiUtils.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/PsiUtils.kt
@@ -143,7 +143,7 @@ object PsiUtils {
         return if (item.childrenPath.isEmpty()) ktFile else getElementByFileAndPath(ktFile, item.childrenPath)
     }
 
-    private fun <T : PsiChildrenPathIndex> getElementByFileAndPath(ktFile: KtFile, path: List<T>): KtExpression? {
+    fun <T : PsiChildrenPathIndex> getElementByFileAndPath(ktFile: KtFile, path: List<T>): KtExpression? {
         var currentDepth = 0
         var element: PsiElement = ktFile
         while (currentDepth < path.size) {

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/UsedPsiElementGetter.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/psi/UsedPsiElementGetter.kt
@@ -1,12 +1,11 @@
 package org.plan.research.minimization.plugin.psi
 
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.idea.base.psi.isConstructorDeclaredProperty
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtVisitorVoid
 
@@ -32,11 +31,9 @@ class UsedPsiElementGetter(private val insideFunction: Boolean) : KtVisitorVoid(
     } ?: super.visitNamedFunction(function)
 
     override fun visitProperty(property: KtProperty) =
-        if (isVisitPropertyRequired(property)) super.visitProperty(property) else Unit
+        if (insideFunction) super.visitProperty(property) else Unit
 
-    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
-        super.visitDotQualifiedExpression(expression)
-    }
+    override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) = Unit
 
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
@@ -44,11 +41,5 @@ class UsedPsiElementGetter(private val insideFunction: Boolean) : KtVisitorVoid(
             KotlinElementLookup.lookupDefinition(element),
         )
         element.acceptChildren(this)
-    }
-
-    private fun isVisitPropertyRequired(element: KtProperty): Boolean = when {
-        insideFunction -> true
-        element.isConstructorDeclaredProperty() -> true
-        else -> false
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationStageExecutorService.kt
@@ -140,9 +140,10 @@ class MinimizationStageExecutorService(private val project: Project) : Minimizat
 
         val ddAlgorithm = declarationLevelStage.ddAlgorithm.getDDAlgorithm()
         val hierarchicalDD = HierarchicalDD(ddAlgorithm)
-        val hierarchy = DeletablePsiElementHierarchyGenerator<DeclarationLevelStageContext>(declarationLevelStage.depthThreshold)
-            .produce(lightContext)
-            .getOrElse { raise(MinimizationError.HierarchyFailed(it)) }
+        val hierarchy =
+            DeletablePsiElementHierarchyGenerator<DeclarationLevelStageContext>(declarationLevelStage.depthThreshold)
+                .produce(lightContext)
+                .getOrElse { raise(MinimizationError.HierarchyFailed(it)) }
 
         lightContext.runMonadWithProgress {
             hierarchicalDD.minimize(hierarchy)
@@ -162,7 +163,8 @@ class MinimizationStageExecutorService(private val project: Project) : Minimizat
         val importRefCounter = KtSourceImportRefCounter.create(context).getOrElse {
             raise(MinimizationError.AnalysisFailed)
         }
-        val graph = service<MinimizationPsiManagerService>().buildDeletablePsiGraph(context)
+        val graph = service<MinimizationPsiManagerService>()
+            .buildDeletablePsiGraph(context, declarationGraphStage.isFunctionParametersEnabled)
         val condensedGraph = StrongConnectivityCondensation.compressGraph(graph)
 
         val lightContext = DeclarationGraphLevelStageContext(

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/TestGraphService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/TestGraphService.kt
@@ -21,7 +21,7 @@ class TestGraphService(private val project: Project, private val coroutineScope:
     fun dumpGraph() = coroutineScope.launch {
         val context = DefaultProjectContext(project)
         val graph = service<MinimizationPsiManagerService>()
-            .buildDeletablePsiGraph(context)
+            .buildDeletablePsiGraph(context, true)
         val representation = GraphToImageDumper.dumpGraph(
             graph,
             stringify = { it.toString() },

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/ui/StagesSettingsProducer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/settings/ui/StagesSettingsProducer.kt
@@ -97,6 +97,11 @@ class StagesSettingsProducer {
             .apply { comment?.bind(commentText) }
     }
 
+    private fun Row.booleanProperty(graph: PropertyGraph, property: GraphProperty<Boolean>, text: String = "") {
+        checkBox(text)
+            .bindSelected(property)
+    }
+
     private fun <T : MinimizationStage, V> PropertyGraph.stageProperty(
         stageProperty: GraphProperty<T>,
         lens: Lens<T, V>,
@@ -159,12 +164,16 @@ class StagesSettingsProducer {
         stageProperty: GraphProperty<DeclarationGraphStage>,
     ): DialogPanel = panel {
         val ddAlgorithm = graph.stageProperty(stageProperty, DeclarationGraphStage.ddAlgorithm)
+        val withFunctionParameters = graph.stageProperty(stageProperty, DeclarationGraphStage.isFunctionParametersEnabled)
         row("Description:") {
             text("The algorithm removes declarations, e.g. classes, functions and fields using a graph approach.")
         }
         group("Declaration Graph Level Settings", indent = false) {
             row("Minimization strategy:") {
                 strategy(graph, ddAlgorithm)
+            }
+            row {
+                booleanProperty(graph, withFunctionParameters, "Delete function and constructor parameters")
             }
         }
     }

--- a/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
@@ -125,7 +125,8 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
         val allItems = runBlocking { getAllItems(context) }
-        val items = runBlocking { readAction { allItems.filterByPsi(context) { it is KtNamedFunction && it.name != "h" } } }
+        val items =
+            runBlocking { readAction { allItems.filterByPsi(context) { it is KtNamedFunction && it.name != "h" } } }
         runBlocking {
             doTest(context, items, "project-import-optimizing-modified-f-g")
         }
@@ -250,13 +251,31 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val itemsToDelete = runBlocking {
             readAction {
                 listOf(
-                    allItems.findByPsi(context) { it is KtParameter && it.name == "b"  }!!,
-                    allItems.findByPsi(context) { it is KtParameter && it.name == "x"  }!!
+                    allItems.findByPsi(context) { it is KtParameter && it.name == "b" }!!,
+                    allItems.findByPsi(context) { it is KtParameter && it.name == "x" }!!
                 )
             }
         }
         runBlocking {
             doTest(context, itemsToDelete, "project-delete-function-parameter-result")
+        }
+    }
+
+    fun testDeletingConstructorCallWithImport() {
+        myFixture.copyDirectoryToProject("project-call-deletion-import", ".")
+        val importRefCounter = runBlocking {
+            KtSourceImportRefCounter.create(HeavyTestContext(project)).getOrNull()
+        }
+        kotlin.test.assertNotNull(importRefCounter)
+        val context = TestContext(project, importRefCounter)
+        val allItems = runBlocking { getAllItems(context) }
+        val itemsToDelete = runBlocking {
+            readAction {
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "x" }
+            }
+        }
+        runBlocking {
+            doTest(context, itemsToDelete, "project-call-deletion-import-result")
         }
     }
 }

--- a/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
 import org.plan.research.minimization.plugin.lenses.FunctionDeletingLens
 import org.plan.research.minimization.plugin.model.context.IJDDContextCloner
 import org.plan.research.minimization.plugin.model.context.LightIJDDContext
@@ -22,6 +23,7 @@ import org.plan.research.minimization.plugin.model.context.WithImportRefCounterC
 import org.plan.research.minimization.plugin.model.item.PsiStubDDItem
 import org.plan.research.minimization.plugin.psi.KtSourceImportRefCounter
 import org.plan.research.minimization.plugin.psi.stub.KtFunctionStub
+import org.plan.research.minimization.plugin.psi.stub.KtPrimaryConstructorStub
 import org.plan.research.minimization.plugin.psi.stub.KtStub
 import org.plan.research.minimization.plugin.services.MinimizationPsiManagerService
 import org.plan.research.minimization.plugin.services.ProjectCloningService
@@ -38,7 +40,7 @@ class TestContext(
 
     constructor(
         project: Project,
-        importRefCounter : KtSourceImportRefCounter,
+        importRefCounter: KtSourceImportRefCounter,
     ) : this(project.guessProjectDir()!!, project, project, importRefCounter)
 
     override fun copy(projectDir: VirtualFile): TestContext =
@@ -56,7 +58,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
     override suspend fun getAllItems(context: TestContext): List<PsiStubDDItem> {
         configureModules(context.indexProject)
         return service<MinimizationPsiManagerService>()
-            .findDeletablePsiItems(context)
+            .findDeletablePsiItems(context, compressOverridden = false, withFunctionParameters = true)
     }
 
     override fun getTestDataPath() = "src/test/resources/testData/function-deleting"
@@ -69,7 +71,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
 
-        runBlocking { doTest(context, emptyList(), "project-simple-modified-all") }
+        runBlocking { doTest(context, getAllItems(context), "project-simple-modified-all") }
     }
 
     fun testSimpleProjectOdd() {
@@ -81,7 +83,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val context = TestContext(project, importRefCounter)
 
         val allItems = runBlocking { getAllItems(context) }
-        val items = allItems.filterIndexed { index, _ -> index % 2 == 0 }
+        val items = allItems.filterIndexed { index, _ -> index % 2 != 0 }
         runBlocking { doTest(context, items, "project-simple-modified-odd") }
     }
 
@@ -94,9 +96,9 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val context = TestContext(project, importRefCounter)
         runBlocking {
             val firstStage =
-                getAllItems(context).filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "g" }
+                getAllItems(context).filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name == "g" }
             val afterTestContext = doTest(context, firstStage, "project-simple-multistage-1")
-            val secondStage = readAction { firstStage.filterByPsi(context) { it !is KtClass } }
+            val secondStage = getAllItems(context).let { readAction { it.filterByPsi(context) { it is KtClass } } }
             doTest(afterTestContext, secondStage, "project-simple-multistage-2")
         }
     }
@@ -109,7 +111,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
         val allItems = runBlocking { getAllItems(context) }
-        val items = allItems.filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "h" }
+        val items = allItems.filterNot { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "h" }
         runBlocking {
             doTest(context, items, "project-import-optimizing-modified-h")
         }
@@ -123,7 +125,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
         val allItems = runBlocking { getAllItems(context) }
-        val items = allItems.filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name == "h" }
+        val items = runBlocking { readAction { allItems.filterByPsi(context) { it is KtNamedFunction && it.name != "h" } } }
         runBlocking {
             doTest(context, items, "project-import-optimizing-modified-f-g")
         }
@@ -138,9 +140,10 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val context = TestContext(project, importRefCounter)
         runBlocking {
             val firstStage =
-                getAllItems(context).filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "h" }
+                getAllItems(context).filterNot { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "h" }
             val afterTestContext = doTest(context, firstStage, "project-import-optimizing-modified-h")
-            val secondStage = readAction { firstStage.filterByPsi(context) { it !is KtNamedFunction } }
+            val secondStage =
+                getAllItems(context).let { readAction { it.filterByPsi(context) { it is KtNamedFunction } } }
             doTest(afterTestContext, secondStage, "project-import-optimizing-modified-h-stage-2")
         }
     }
@@ -155,9 +158,10 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val context = TestContext(project, importRefCounter)
         runBlocking {
             val firstStage =
-                getAllItems(context).filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name != "f" }
+                getAllItems(context).filter { (it.childrenPath.singleOrNull() as? KtFunctionStub)?.name == "f" }
             val afterTestContext = doTest(context, firstStage, "project-import-star-stage-1")
-            val secondStage = readAction { firstStage.filterByPsi(context) { it !is KtNamedFunction } }
+            val secondStage =
+                getAllItems(context).let { readAction { it.filterByPsi(context) { it is KtNamedFunction && it.name == "g" } } }
             doTest(afterTestContext, secondStage, "project-import-star-stage-2")
         }
     }
@@ -178,15 +182,14 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
             val psiFile = readAction { cloned.projectDir.findFile("a.kt")!!.toPsiFile(cloned.indexProject)!! }
             readAction { assertTrue(psiFile.isValid) }
             val lens = getLens()
-            val items = getAllItems(context)
             cloned = cloned.runMonad {
-                lens.focusOn(items)
+                lens.focusOn(emptyList())
             }
             withContext(Dispatchers.EDT) {
                 PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
             }
-            readAction { assertFalse(psiFile.isValid) }
-            assertFalse(cloned.projectDir.toNioPath().resolve("a.kt").exists())
+            readAction { assertTrue(psiFile.isValid) }
+            assertTrue(cloned.projectDir.toNioPath().resolve("a.kt").exists())
         }
     }
 
@@ -198,7 +201,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
         val allItems = runBlocking { getAllItems(context) }
-        val items = allItems.filter { it.childrenPath.size == 1 }
+        val items = allItems.filterNot { it.childrenPath.size == 1 }
         runBlocking {
             doTest(context, items, "project-overridden-multiple-files-result")
         }
@@ -212,9 +215,48 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         kotlin.test.assertNotNull(importRefCounter)
         val context = TestContext(project, importRefCounter)
         val allItems = runBlocking { getAllItems(context) }
-        val items = allItems.filter { it.childrenPath.size == 1 && it.childrenPath.singleOrNull()?.let {it is KtFunctionStub && it.name == "y"} == true }
+        val items = allItems.filterNot {
+            it.childrenPath.size == 1 && it.childrenPath.singleOrNull()
+                ?.let { it is KtFunctionStub && it.name == "y" } == true
+        }
         runBlocking {
             doTest(context, items, "project-import-receiver-result")
+        }
+    }
+
+    fun testDeletingConstructorParameterSimple() {
+        myFixture.copyDirectoryToProject("project-delete-constructor-parameter-simple", ".")
+        val importRefCounter = runBlocking {
+            KtSourceImportRefCounter.create(HeavyTestContext(project)).getOrNull()
+        }
+        kotlin.test.assertNotNull(importRefCounter)
+        val context = TestContext(project, importRefCounter)
+        val allItems = runBlocking { getAllItems(context) }
+        val items =
+            allItems.filter { it.childrenPath.any { it is KtPrimaryConstructorStub } && it.childrenPath.last().name == "x" }
+        runBlocking {
+            doTest(context, items, "project-delete-constructor-parameter-simple-result")
+        }
+    }
+
+    fun testDeletingFunctionParameters() {
+        myFixture.copyDirectoryToProject("project-delete-function-parameter", ".")
+        val importRefCounter = runBlocking {
+            KtSourceImportRefCounter.create(HeavyTestContext(project)).getOrNull()
+        }
+        kotlin.test.assertNotNull(importRefCounter)
+        val context = TestContext(project, importRefCounter)
+        val allItems = runBlocking { getAllItems(context) }
+        val itemsToDelete = runBlocking {
+            readAction {
+                listOf(
+                    allItems.findByPsi(context) { it is KtParameter && it.name == "b"  }!!,
+                    allItems.findByPsi(context) { it is KtParameter && it.name == "x"  }!!
+                )
+            }
+        }
+        runBlocking {
+            doTest(context, itemsToDelete, "project-delete-function-parameter-result")
         }
     }
 }

--- a/project-minimization-plugin/src/test/kotlin/lens/PsiLensTestBase.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/PsiLensTestBase.kt
@@ -32,10 +32,9 @@ abstract class PsiLensTestBase<C : LightIJDDContext<C>, ITEM, T> :
         val cloned = projectCloningService.clone(initialContext) as C
         kotlin.test.assertNotNull(cloned)
         val lens = getLens()
-        val items = getAllItems(cloned)
 
         return cloned.runMonad {
-            lens.focusOn(items - elements.toSet())
+            lens.focusOn(elements)
 
             val files = smartReadAction(context.indexProject) {
                 val fileIndex = ProjectRootManager.getInstance(context.indexProject).fileIndex

--- a/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
@@ -179,7 +179,7 @@ class InstanceLevelGraphCollectionTest : AbstractAnalysisKotlinTest() {
             configureModules(myFixture.project)
             val context = DefaultProjectContext(project)
             DumbService.getInstance(project).waitForSmartMode()
-            val graph = service<MinimizationPsiManagerService>().buildDeletablePsiGraph(context)
+            val graph = service<MinimizationPsiManagerService>().buildDeletablePsiGraph(context, true)
             withContext(Dispatchers.EDT) {
                 PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
             }

--- a/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.plan.research.minimization.plugin.model.context.IJDDContext
@@ -74,6 +75,7 @@ class InstanceLevelGraphCollectionTest : AbstractAnalysisKotlinTest() {
             val funG = graph.findByClassAndName<KtNamedFunction>(context, "g").single()
             val valX = graph.findByClassAndName<KtProperty>(context, "x").single()
             val valY = graph.findByClassAndName<KtProperty>(context, "y").single()
+            val parameterX = graph.findByClassAndName<KtParameter>(context, "x").single()
 
             val allElements = listOf(
                 interfaceA,
@@ -88,13 +90,14 @@ class InstanceLevelGraphCollectionTest : AbstractAnalysisKotlinTest() {
                 classGG,
                 funG,
                 valX,
-                valY
+                valY,
+                parameterX
             )
 
             val file = graph.findByClassAndName<KtFile>(context, "complex-overload.kt").single()
             val dir = graph.findByClassAndName<PsiDirectory>(context, null).single()
 
-            assertSize(25 + allElements.size, graph.edges)
+            assertSize(26 + allElements.size, graph.edges)
             graph.assertConnection<PsiIJEdge.PSITreeEdge>(funFA, interfaceA)
 
             graph.assertConnection<PsiIJEdge.PSITreeEdge>(funFC, interfaceC)
@@ -121,8 +124,10 @@ class InstanceLevelGraphCollectionTest : AbstractAnalysisKotlinTest() {
             graph.assertConnection<PsiIJEdge.PSITreeEdge>(valY, funG)
             graph.assertConnection<PsiIJEdge.UsageInPSIElement>(funG, classD) // x2
             graph.assertConnection<PsiIJEdge.UsageInPSIElement>(overrideOverrideFunF, funG)
-            graph.assertConnection<PsiIJEdge.UsageInPSIElement>(classGG, interfaceA)
             graph.assertConnection<PsiIJEdge.UsageInPSIElement>(classE, classD)
+
+            graph.assertConnection<PsiIJEdge.PSITreeEdge>(parameterX, classGG)
+            graph.assertConnection<PsiIJEdge.UsageInPSIElement>(parameterX, interfaceA)
 
             allElements.forEach {
                 graph.assertConnection<PsiIJEdge.PSITreeEdge>(it, file)

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-call-deletion-import-result/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-call-deletion-import-result/A.kt
@@ -1,0 +1,5 @@
+class A()
+
+fun f(y: Double) {
+    println(A())
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-call-deletion-import/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-call-deletion-import/A.kt
@@ -1,0 +1,6 @@
+import kotlin.math.log
+class A(val x: Double)
+
+fun f(y: Double) {
+    println(A(log(y)))
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-constructor-parameter-simple-result/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-constructor-parameter-simple-result/A.kt
@@ -1,0 +1,6 @@
+class A(val y: Int)
+
+fun f() {
+    val a = A(2)
+    println(a.y)
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-constructor-parameter-simple/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-constructor-parameter-simple/A.kt
@@ -1,0 +1,6 @@
+class A(val x: Int, val y: Int)
+
+fun f() {
+    val a = A(1, 2)
+    println(a.y)
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-function-parameter-result/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-function-parameter-result/A.kt
@@ -1,0 +1,13 @@
+class A(
+    val a: Int = 5,
+) {
+    fun method(y: Double) = Unit
+    fun method2(z: Int) {
+        method(5.0)
+    }
+}
+
+fun main() {
+    A()
+    A(5)
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-function-parameter/A.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-deleting/project-delete-function-parameter/A.kt
@@ -1,0 +1,14 @@
+class A(
+    val a: Int = 5,
+    val b: () -> Unit,
+) {
+    fun method(x: Int, y: Double) = Unit
+    fun method2(z: Int) {
+        method(z, 5.0)
+    }
+}
+
+fun main() {
+    A() { println() }
+    A(5) { Unit }
+}


### PR DESCRIPTION
This PR adds support for deleting the constructors/functions parameters

## How to test

### Automated tests

For now, some tests are added to `DeclarationDeletingLensTest`

### Manual tests

It is implemented to the Declaration-level graph stage. You can run benchmarks.

## Self-check list

- [x] PR **title** and **description** are clear and aligned with a format.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas. 
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [ ] **Manual tests** have been provided _optionally_.
- [ ] The **documentation** for the functionality I've been working on is up-to-date/provided.
- [x] The **link** to this PR is commented on in the corresponding **YT ticket**.

Hint: [x] is a marked item
