### PR TITLE
JBRes-???? Support Java in Function Modification Stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,45 @@
 # Project Minimization
 
-The project minimization tool is an IntelliJ IDEA plugin that aims to reduce the size of projects localizing Kotlin compiler faults.
+The project minimization tool is an IntelliJ IDEA plugin that aims to reduce the size of projects localizing Kotlin
+compiler faults.
 
 ## How to build
 
 You need to run the following command to build the plugin:
+
 ```bash
 ./gradlew buildPlugin
 ```
 
-The plugin artefact will be placed in `project-minimization-plugin/build/distributions/project-minimization-plugin-*.zip`.
+The plugin artefact will be placed in
+`project-minimization-plugin/build/distributions/project-minimization-plugin-*.zip`.
 
 ## How to run
 
 There are two ways to run the plugin:
-- Get from the releases or build the plugin as a `zip` file and install it into your IDE via [a standard pipeline](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
+
+- Get from the releases or build the plugin as a `zip` file and install it into your IDE
+  via [a standard pipeline](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
 - Run the following command, which executes a new instance of IntelliJ IDEA with the preinstalled plugin:
+
 ```bash
 ./gradlew runIde
 ```
 
-As soon as an IDE with the installed plugin is executed, you can perform an action `Minimize Project` on an opened project. 
+As soon as an IDE with the installed plugin is executed, you can perform an action `Minimize Project` on an opened
+project.
 The action can be found in the `Tools` menu bar or via search.
 
-It is expected that during minimization, several new projects can be opened and closed. 
-It's necessary to perform safe actions without affecting the original project. At the end of the minimization process, only one extra window with the minimized project should be opened.
+It is expected that during minimization, several new projects can be opened and closed.
+It's necessary to perform safe actions without affecting the original project. At the end of the minimization process,
+only one extra window with the minimized project should be opened.
 
 ## Limitations
 
 Now, minimization supports only gradle projects.
 
-It also minimizes well only kotlin files,
-while java and other files are being minimized without any complex modifications.
+It also minimizes well only kotlin files, java source files have limited support, and other files are minimized without
+complex modifications.
 
 As a consequence, this tool doesn't minimize build files and files related to project building, e.g. `buildSrc`.
 
@@ -65,17 +73,17 @@ As a rule, build files such as a `buildSrc` folder cannot be minimized, so it wi
 - **Gradle task**: Specifies the Gradle task to reproduce the fault.
 
 - **Gradle options**: Specifies the additional options to the specified Gradle task.
-Options `--no-configuration-cache`, `--no-build-cache` and `--quiet` are always passed.
+  Options `--no-configuration-cache`, `--no-build-cache` and `--quiet` are always passed.
 
 - **Temporary project location**: Specifies the folder's name for storing project snapshots.
-The resulting project will be placed into this directory.
+  The resulting project will be placed into this directory.
 
 - **Logs location**: Specifies the folder's name where logs should be placed.
 
 - **Snapshot strategy**: Determines the snapshot strategy, namely how the tool makes temporary modifications.
 
 - **Exception comparing strategy**: Configures the exception comparison strategy.
-It's recommended to use the `STACKTRACE` comparison.
+  It's recommended to use the `STACKTRACE` comparison.
 
 - **Stages**: Defines a list of minimization stages. It's recommended to use default setting.
 
@@ -89,9 +97,13 @@ The resulting project can be incorrect in terms of reproducing the initial compi
 namely, the initial exception can be lost.
 
 There are several possible reasons:
-1. Exceptions were too similar in terms of *Exception comparing strategy*. Possible solution: change the corresponding setting.
-2. The initial exception isn't reproduced at the beginning of minimization. Possible solution: clean the build cache and restart your IDE.
-3. The exception is cached, so modifications didn't affect the build task. Possible solution: remake the build task to clean all caches after the end of its execution.
+
+1. Exceptions were too similar in terms of *Exception comparing strategy*. Possible solution: change the corresponding
+   setting.
+2. The initial exception isn't reproduced at the beginning of minimization. Possible solution: clean the build cache and
+   restart your IDE.
+3. The exception is cached, so modifications didn't affect the build task. Possible solution: remake the build task to
+   clean all caches after the end of its execution.
 
 ### Minimization cannot be executed or ended without results
 
@@ -110,4 +122,5 @@ Tip: use the *Ignore paths* setting.
 
 ## Documentation
 
-The project documentation, including detailed descriptions of the algorithms and general pipeline, can be found [here](docs/OverallArchitecture.md).
+The project documentation, including detailed descriptions of the algorithms and general pipeline, can be
+found [here](docs/OverallArchitecture.md).

--- a/docs/plugin/MinimizationStages.md
+++ b/docs/plugin/MinimizationStages.md
@@ -1,40 +1,62 @@
 # Minimization Stages
 
-This document describes the different minimization stages implemented by the plugin. Each stage is responsible for reducing the project size by applying delta-debugging (DD) algorithms along with specialized lenses and PSI services provided by the [MinimizationService][service].
+This document describes the different minimization stages implemented by the plugin. Each stage is responsible for
+reducing the project size by applying delta-debugging (DD) algorithms along with specialized lenses and PSI services
+provided by the [MinimizationService][service].
 
 ## File-Level Stage
 
 The File-Level stage focuses on minimizing the project at the granularity of individual source files. Key steps include:
 
-- Initializing a file hierarchy using the FileTreeHierarchyFactory, which organizes source files into a structured tree based on their paths.
-- Running a hierarchical delta debugging algorithm ([HierarchicalDD](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FileLevelStage.kt)) on the constructed file hierarchy. This iterative process removes files while ensuring the minimized project still meets the required property.
+- Initializing a file hierarchy using the FileTreeHierarchyFactory, which organizes source files into a structured tree
+  based on their paths.
+- Running a hierarchical delta debugging
+  algorithm ([HierarchicalDD](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FileLevelStage.kt))
+  on the constructed file hierarchy. This iterative process removes files while ensuring the minimized project still
+  meets the required property.
 - Logging progress and handling any errors via the MinimizationError mechanism.
 
 ## Function-Level Stage
 
-The Function-Level stage targets code elements that contain executable bodies, such as functions, lambdas, class initializers, and custom getter/setters. Key aspects are:
+The Function-Level stage targets code elements that contain executable bodies, such as functions, lambdas, class
+initializers, and custom getter/setters.
+For Java, replacing method and lambda bodies is supported.
+Key aspects are:
 
-- Collecting all top-level PSI elements with bodies using the [MinimizationPsiManagerService](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt) to construct a set of items (PsiWithBodyDDItem).
-- Utilizing a FunctionModificationLens to focus on the parts of these elements that can be safely minimized.
-- Applying the DD algorithm (DDAlgorithm) with a property tester (commonly based on SameExceptionPropertyTester) to validate that the minimized version retains essential properties like compilation and exception behavior.
-- Replacing the minimized function body with a placeholder (e.g., `TODO("Replaced by DD")`) to signify that the body has been reduced.
+- Collecting all top-level PSI elements with bodies using
+  the [MinimizationPsiManagerService](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt)
+  to construct a set of items (PsiWithBodyDDItem).
+- Using a FunctionModificationLens to focus on the parts of these elements that can be safely minimized.
+- Applying the DD algorithm (DDAlgorithm) with a property tester (commonly based on SameExceptionPropertyTester) to
+  validate that the minimized version retains essential properties like compilation and exception behavior.
+- Replacing the minimized function body with a placeholder (e.g., `TODO("Replaced by DD")` or
+  `throw new UnsupportedOperationException("Removed by DD")`) to signify that the body has
+  been reduced.
 - The process is integrated into the overall minimization flow provided by the [MinimizationService][service].
 
 ## Declaration-Graph-Level Stage
 
-The Declaration-Graph-Level stage operates at the level of code declarations and their dependencies by leveraging a graph-based approach:
+The Declaration-Graph-Level stage operates at the level of code declarations and their dependencies by leveraging a
+graph-based approach:
 
-- Building a deletable PSI graph that represents code declarations and their interdependencies through the [MinimizationPsiManagerService](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt).
-- Employing a graph delta debugging algorithm ([GraphDD](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/DeclarationGraphLevelStage.kt)) enhanced with condensation to simplify the graph structure.
-- Creating a property tester using a FunctionDeletingLens to ensure that deletion of certain declarations does not result in errors.
-- Integrating supporting mechanisms such as a KtSourceImportRefCounter for automatically removing unused import statements, and a call trace parameter cache to correctly manage function call dependencies.
+- Building a deletable PSI graph that represents code declarations and their interdependencies through
+  the [MinimizationPsiManagerService](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt).
+- Employing a graph delta debugging
+  algorithm ([GraphDD](../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/DeclarationGraphLevelStage.kt))
+  enhanced with condensation to simplify the graph structure.
+- Creating a property tester using a FunctionDeletingLens to ensure that deletion of certain declarations does not
+  result in errors.
+- Integrating supporting mechanisms such as a KtSourceImportRefCounter for automatically removing unused import
+  statements, and a call trace parameter cache to correctly manage function call dependencies.
 
 ## Common Execution Pattern
 
 All stages follow a common framework as defined in the MinimizationStageBase:
 
-- They create a specialized context (e.g., FileLevelStageContext, FunctionLevelStageContext, DeclarationLevelStageContext) derived from the overall project context.
+- They create a specialized context (e.g., FileLevelStageContext, FunctionLevelStageContext,
+  DeclarationLevelStageContext) derived from the overall project context.
 - Execution runs within a snapshot monad that preserves state and manages progress logging.
-- Each stage logs its start and end, and any errors are reported transparently via the logging mechanism, ensuring reliable tracking of the minimization process.
+- Each stage logs its start and end, and any errors are reported transparently via the logging mechanism, ensuring
+  reliable tracking of the minimization process.
 
 [service]: ../../project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationService.kt

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
@@ -11,20 +11,9 @@ import org.plan.research.minimization.plugin.services.MinimizationPsiManagerServ
 
 import arrow.core.getOrElse
 import arrow.core.raise.Raise
-import arrow.core.right
 import com.intellij.openapi.components.service
 import mu.KLogger
 import mu.KotlinLogging
-
-import org.plan.research.minimization.plugin.algorithm.tester.SameExceptionPropertyTester
-import org.plan.research.minimization.plugin.compilation.BuildExceptionProvider
-import org.plan.research.minimization.plugin.compilation.CompilationResult
-import org.plan.research.minimization.plugin.compilation.DumbCompiler
-import org.plan.research.minimization.plugin.context.IJDDContext
-import org.plan.research.minimization.plugin.logging.LoggingPropertyCheckingListener
-import org.plan.research.minimization.plugin.services.BuildExceptionProviderService
-import org.plan.research.minimization.plugin.services.MinimizationPluginSettings
-import org.plan.research.minimization.plugin.util.getExceptionComparator
 
 class FunctionLevelStage(
     private val ddAlgorithm: DDAlgorithm,
@@ -46,24 +35,24 @@ class FunctionLevelStage(
             }
 
         // TODO: Remove
-//        class MyExceptionProvider : BuildExceptionProvider {
-//            private val THROWABLE = Throwable("Test")
-//            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
-//                DumbCompiler.DumbException(THROWABLE).right()
-//        }
-//
-//        val propertyChecker = SameExceptionPropertyTester.create(
-//            MyExceptionProvider(),
-//            context.originalProject.service<MinimizationPluginSettings>().state
-//                .exceptionComparingStrategy
-//                .getExceptionComparator(),
-//            lens,
-//            context,
-//            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
-//        ).getOrElse {
-//            logger.error { "Property checker creation failed. Aborted" }
-//            raise(MinimizationError.PropertyCheckerFailed)
-//        }
+        // class MyExceptionProvider : BuildExceptionProvider {
+        // private val THROWABLE = Throwable("Test")
+        // override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
+        // DumbCompiler.DumbException(THROWABLE).right()
+        // }
+        // 
+        // val propertyChecker = SameExceptionPropertyTester.create(
+        // MyExceptionProvider(),
+        // context.originalProject.service<MinimizationPluginSettings>().state
+        // .exceptionComparingStrategy
+        // .getExceptionComparator(),
+        // lens,
+        // context,
+        // listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
+        // ).getOrElse {
+        // logger.error { "Property checker creation failed. Aborted" }
+        // raise(MinimizationError.PropertyCheckerFailed)
+        // }
 
         ddAlgorithm.minimize(
             firstLevel,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
@@ -11,9 +11,20 @@ import org.plan.research.minimization.plugin.services.MinimizationPsiManagerServ
 
 import arrow.core.getOrElse
 import arrow.core.raise.Raise
+import arrow.core.right
 import com.intellij.openapi.components.service
 import mu.KLogger
 import mu.KotlinLogging
+
+import org.plan.research.minimization.plugin.algorithm.tester.SameExceptionPropertyTester
+import org.plan.research.minimization.plugin.compilation.BuildExceptionProvider
+import org.plan.research.minimization.plugin.compilation.CompilationResult
+import org.plan.research.minimization.plugin.compilation.DumbCompiler
+import org.plan.research.minimization.plugin.context.IJDDContext
+import org.plan.research.minimization.plugin.logging.LoggingPropertyCheckingListener
+import org.plan.research.minimization.plugin.services.BuildExceptionProviderService
+import org.plan.research.minimization.plugin.services.MinimizationPluginSettings
+import org.plan.research.minimization.plugin.util.getExceptionComparator
 
 class FunctionLevelStage(
     private val ddAlgorithm: DDAlgorithm,
@@ -26,12 +37,27 @@ class FunctionLevelStage(
         val lens = FunctionModificationLens<FunctionLevelStageContext>()
         val firstLevel = service<MinimizationPsiManagerService>()
             .findAllPsiWithBodyItems(context)
-        val propertyChecker = PropertyTesterFactory
-            .createPropertyTester(lens, context, stageName)
-            .getOrElse {
-                logger.error { "Property checker creation failed. Aborted" }
-                raise(MinimizationError.PropertyCheckerFailed)
-            }
+
+        //        val propertyChecker = PropertyTesterFactory
+        //            .createPropertyTester(lens, context, stageName)
+        class MyExceptionProvider : BuildExceptionProvider {
+            private val THROWABLE = Throwable("Test")
+            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
+                DumbCompiler.DumbException(THROWABLE).right()
+        }
+
+        val propertyChecker = SameExceptionPropertyTester.create(
+            MyExceptionProvider(),
+            context.originalProject.service<MinimizationPluginSettings>().state
+                .exceptionComparingStrategy
+                .getExceptionComparator(),
+            lens,
+            context,
+            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
+        ).getOrElse {
+            logger.error { "Property checker creation failed. Aborted" }
+            raise(MinimizationError.PropertyCheckerFailed)
+        }
 
         ddAlgorithm.minimize(
             firstLevel,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
@@ -38,26 +38,32 @@ class FunctionLevelStage(
         val firstLevel = service<MinimizationPsiManagerService>()
             .findAllPsiWithBodyItems(context)
 
-        //        val propertyChecker = PropertyTesterFactory
-        //            .createPropertyTester(lens, context, stageName)
-        class MyExceptionProvider : BuildExceptionProvider {
-            private val THROWABLE = Throwable("Test")
-            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
-                DumbCompiler.DumbException(THROWABLE).right()
-        }
+        val propertyChecker = PropertyTesterFactory
+            .createPropertyTester(lens, context, stageName)
+            .getOrElse {
+                logger.error { "Property checker creation failed. Aborted" }
+                raise(MinimizationError.PropertyCheckerFailed)
+            }
 
-        val propertyChecker = SameExceptionPropertyTester.create(
-            MyExceptionProvider(),
-            context.originalProject.service<MinimizationPluginSettings>().state
-                .exceptionComparingStrategy
-                .getExceptionComparator(),
-            lens,
-            context,
-            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
-        ).getOrElse {
-            logger.error { "Property checker creation failed. Aborted" }
-            raise(MinimizationError.PropertyCheckerFailed)
-        }
+        // TODO: Remove
+//        class MyExceptionProvider : BuildExceptionProvider {
+//            private val THROWABLE = Throwable("Test")
+//            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
+//                DumbCompiler.DumbException(THROWABLE).right()
+//        }
+//
+//        val propertyChecker = SameExceptionPropertyTester.create(
+//            MyExceptionProvider(),
+//            context.originalProject.service<MinimizationPluginSettings>().state
+//                .exceptionComparingStrategy
+//                .getExceptionComparator(),
+//            lens,
+//            context,
+//            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
+//        ).getOrElse {
+//            logger.error { "Property checker creation failed. Aborted" }
+//            raise(MinimizationError.PropertyCheckerFailed)
+//        }
 
         ddAlgorithm.minimize(
             firstLevel,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
@@ -2,23 +2,15 @@ package org.plan.research.minimization.plugin.algorithm.stages
 
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithm
 import org.plan.research.minimization.plugin.algorithm.MinimizationError
-import org.plan.research.minimization.plugin.algorithm.tester.SameExceptionPropertyTester
-import org.plan.research.minimization.plugin.compilation.BuildExceptionProvider
-import org.plan.research.minimization.plugin.compilation.CompilationResult
-import org.plan.research.minimization.plugin.compilation.DumbCompiler
+import org.plan.research.minimization.plugin.algorithm.tester.PropertyTesterFactory
 import org.plan.research.minimization.plugin.context.HeavyIJDDContext
-import org.plan.research.minimization.plugin.context.IJDDContext
 import org.plan.research.minimization.plugin.context.impl.FunctionLevelStageContext
 import org.plan.research.minimization.plugin.context.snapshot.SnapshotMonad
-import org.plan.research.minimization.plugin.logging.LoggingPropertyCheckingListener
 import org.plan.research.minimization.plugin.modification.lenses.FunctionModificationLens
-import org.plan.research.minimization.plugin.services.MinimizationPluginSettings
 import org.plan.research.minimization.plugin.services.MinimizationPsiManagerService
-import org.plan.research.minimization.plugin.util.getExceptionComparator
 
 import arrow.core.getOrElse
 import arrow.core.raise.Raise
-import arrow.core.right
 import com.intellij.openapi.components.service
 import mu.KLogger
 import mu.KotlinLogging
@@ -35,32 +27,12 @@ class FunctionLevelStage(
         val firstLevel = service<MinimizationPsiManagerService>()
             .findAllPsiWithBodyItems(context)
 
-        // val propertyChecker = PropertyTesterFactory
-        // .createPropertyTester(lens, context, stageName)
-        // .getOrElse {
-        // logger.error { "Property checker creation failed. Aborted" }
-        // raise(MinimizationError.PropertyCheckerFailed)
-        // }
-
-        // TODO: Remove
-        class MyExceptionProvider : BuildExceptionProvider {
-            private val THROWABLE = Throwable("Test")
-            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
-                DumbCompiler.DumbException(THROWABLE).right()
-        }
-
-        val propertyChecker = SameExceptionPropertyTester.create(
-            MyExceptionProvider(),
-            context.originalProject.service<MinimizationPluginSettings>().state
-                .exceptionComparingStrategy
-                .getExceptionComparator(),
-            lens,
-            context,
-            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
-        ).getOrElse {
-            logger.error { "Property checker creation failed. Aborted" }
-            raise(MinimizationError.PropertyCheckerFailed)
-        }
+        val propertyChecker = PropertyTesterFactory
+            .createPropertyTester(lens, context, stageName)
+            .getOrElse {
+                logger.error { "Property checker creation failed. Aborted" }
+                raise(MinimizationError.PropertyCheckerFailed)
+            }
 
         ddAlgorithm.minimize(
             firstLevel,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/algorithm/stages/FunctionLevelStage.kt
@@ -2,15 +2,23 @@ package org.plan.research.minimization.plugin.algorithm.stages
 
 import org.plan.research.minimization.core.algorithm.dd.DDAlgorithm
 import org.plan.research.minimization.plugin.algorithm.MinimizationError
-import org.plan.research.minimization.plugin.algorithm.tester.PropertyTesterFactory
+import org.plan.research.minimization.plugin.algorithm.tester.SameExceptionPropertyTester
+import org.plan.research.minimization.plugin.compilation.BuildExceptionProvider
+import org.plan.research.minimization.plugin.compilation.CompilationResult
+import org.plan.research.minimization.plugin.compilation.DumbCompiler
 import org.plan.research.minimization.plugin.context.HeavyIJDDContext
+import org.plan.research.minimization.plugin.context.IJDDContext
 import org.plan.research.minimization.plugin.context.impl.FunctionLevelStageContext
 import org.plan.research.minimization.plugin.context.snapshot.SnapshotMonad
+import org.plan.research.minimization.plugin.logging.LoggingPropertyCheckingListener
 import org.plan.research.minimization.plugin.modification.lenses.FunctionModificationLens
+import org.plan.research.minimization.plugin.services.MinimizationPluginSettings
 import org.plan.research.minimization.plugin.services.MinimizationPsiManagerService
+import org.plan.research.minimization.plugin.util.getExceptionComparator
 
 import arrow.core.getOrElse
 import arrow.core.raise.Raise
+import arrow.core.right
 import com.intellij.openapi.components.service
 import mu.KLogger
 import mu.KotlinLogging
@@ -27,32 +35,32 @@ class FunctionLevelStage(
         val firstLevel = service<MinimizationPsiManagerService>()
             .findAllPsiWithBodyItems(context)
 
-        val propertyChecker = PropertyTesterFactory
-            .createPropertyTester(lens, context, stageName)
-            .getOrElse {
-                logger.error { "Property checker creation failed. Aborted" }
-                raise(MinimizationError.PropertyCheckerFailed)
-            }
-
-        // TODO: Remove
-        // class MyExceptionProvider : BuildExceptionProvider {
-        // private val THROWABLE = Throwable("Test")
-        // override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
-        // DumbCompiler.DumbException(THROWABLE).right()
-        // }
-        // 
-        // val propertyChecker = SameExceptionPropertyTester.create(
-        // MyExceptionProvider(),
-        // context.originalProject.service<MinimizationPluginSettings>().state
-        // .exceptionComparingStrategy
-        // .getExceptionComparator(),
-        // lens,
-        // context,
-        // listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
-        // ).getOrElse {
+        // val propertyChecker = PropertyTesterFactory
+        // .createPropertyTester(lens, context, stageName)
+        // .getOrElse {
         // logger.error { "Property checker creation failed. Aborted" }
         // raise(MinimizationError.PropertyCheckerFailed)
         // }
+
+        // TODO: Remove
+        class MyExceptionProvider : BuildExceptionProvider {
+            private val THROWABLE = Throwable("Test")
+            override suspend fun checkCompilation(context: IJDDContext): CompilationResult =
+                DumbCompiler.DumbException(THROWABLE).right()
+        }
+
+        val propertyChecker = SameExceptionPropertyTester.create(
+            MyExceptionProvider(),
+            context.originalProject.service<MinimizationPluginSettings>().state
+                .exceptionComparingStrategy
+                .getExceptionComparator(),
+            lens,
+            context,
+            listOfNotNull(LoggingPropertyCheckingListener.create(stageName)),
+        ).getOrElse {
+            logger.error { "Property checker creation failed. Aborted" }
+            raise(MinimizationError.PropertyCheckerFailed)
+        }
 
         ddAlgorithm.minimize(
             firstLevel,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
@@ -31,6 +31,12 @@ data class PsiChildrenIndexDDItem(
         val BODY_REPLACEABLE_PSI_JAVA_CLASSES: List<ClassKtExpression> =
             DECLARATIONS_WITH_BODY_JAVA_CLASSES + EXPRESSIONS_WITH_BODY_JAVA_CLASSES
 
+        /**
+         * Check if a [PsiChildrenIndexDDItem] can be created from given [PsiElement]
+         *
+         * @param psiElement The [PsiElement] to check for compatibility.
+         * @return true if the [PsiElement] is compatible, otherwise false.
+         */
         fun isCompatible(psiElement: PsiElement): Boolean {
             val isCompatibleClass = when (psiElement.language) {
                 is KotlinLanguage -> BODY_REPLACEABLE_PSI_JAVA_CLASSES
@@ -41,6 +47,14 @@ data class PsiChildrenIndexDDItem(
             return isCompatibleClass && hasBodyIfAvailable(psiElement) != false
         }
 
+        /**
+         * Determines whether a given [PsiElement] has a body.
+         *
+         * @param psiElement The [PsiElement] to check.
+         * @return true if it does have a body,
+         *         false if it could have one, but does not,
+         *         null if it is not supported
+         */
         fun hasBodyIfAvailable(psiElement: PsiElement): Boolean? = when (psiElement.language) {
             is KotlinLanguage -> DECLARATIONS_WITH_BODY_JAVA_CLASSES
                 .find { it.isInstance(psiElement) }
@@ -53,6 +67,16 @@ data class PsiChildrenIndexDDItem(
             else -> null
         }
 
+        /**
+         * Creates a new [PsiChildrenIndexDDItem] of the given [PsiElement].
+         *
+         * @param element The [PsiElement] to be transformed into a [PsiChildrenIndexDDItem].
+         * @param parentPath The list of indices representing the path **from** the parent element.
+         * @param localPath The local file path associated with the [PsiElement].
+         * @param renderedType An optional string representing the rendered type of the [PsiElement].
+         * @return A new [PsiChildrenIndexDDItem] if the [PsiElement] is compatible.
+         * @throws IllegalStateException If the [PsiElement] is not compatible.
+         */
         @RequiresReadLock
         fun create(
             element: PsiElement,
@@ -67,11 +91,11 @@ data class PsiChildrenIndexDDItem(
                     renderedType,
                 )
             } else {
-                // TODO: Update error
                 error(
                     "Invalid Psi Element. " +
                         "Supported types: " +
                         "KtNamedFunction, KtClassInitializer, KtPropertyAccessor, KtLambdaExpression, " +
+                        "PsiMethodImpl, " +
                         "but got ${element.javaClass.simpleName}",
                 )
             }
@@ -90,7 +114,12 @@ data class PsiChildrenIndexDDItem(
             is KtLambdaExpression -> transform(element)
             is KtPropertyAccessor -> transform(element)
             is PsiMethodImpl -> transform(element)
-            else -> error("Invalid PSI element type: ${element::class.simpleName}. Expected one of: KtClassInitializer, KtNamedFunction, KtLambdaExpression, KtPropertyAccessor")
+            else -> error(
+                "Invalid PSI element type: ${element::class.simpleName}. " +
+                    "Expected one of: " +
+                    "KtClassInitializer, KtNamedFunction, KtLambdaExpression, KtPropertyAccessor, " +
+                    "PsiMethodImpl",
+            )
         }
     }
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
@@ -70,9 +70,9 @@ data class PsiChildrenIndexDDItem(
                 // TODO: Update error
                 error(
                     "Invalid Psi Element. " +
-                            "Supported types: " +
-                            "KtNamedFunction, KtClassInitializer, KtPropertyAccessor, KtLambdaExpression, " +
-                            "but got ${element.javaClass.simpleName}",
+                        "Supported types: " +
+                        "KtNamedFunction, KtClassInitializer, KtPropertyAccessor, KtLambdaExpression, " +
+                        "but got ${element.javaClass.simpleName}",
                 )
             }
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
@@ -2,8 +2,11 @@ package org.plan.research.minimization.plugin.modification.item
 
 import org.plan.research.minimization.plugin.modification.item.index.IntChildrenIndex
 
+import com.intellij.lang.java.JavaLanguage
 import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.PsiMethodImpl
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.*
 
 import java.nio.file.Path
@@ -22,16 +25,33 @@ data class PsiChildrenIndexDDItem(
             KtLambdaExpression::class.java,
             KtClassInitializer::class.java,
         )
+        val JAVA_BODY_REPLACEABLE_PSI_JAVA_CLASSES = listOf(
+            PsiMethodImpl::class.java,
+        )
         val BODY_REPLACEABLE_PSI_JAVA_CLASSES: List<ClassKtExpression> =
             DECLARATIONS_WITH_BODY_JAVA_CLASSES + EXPRESSIONS_WITH_BODY_JAVA_CLASSES
 
-        fun isCompatible(psiElement: PsiElement) =
-            BODY_REPLACEABLE_PSI_JAVA_CLASSES.any { it.isInstance(psiElement) } && hasBodyIfAvailable(psiElement) != false
+        fun isCompatible(psiElement: PsiElement): Boolean {
+            val isCompatibleClass = when (psiElement.language) {
+                is KotlinLanguage -> BODY_REPLACEABLE_PSI_JAVA_CLASSES
+                is JavaLanguage -> JAVA_BODY_REPLACEABLE_PSI_JAVA_CLASSES
+                else -> return false
+            }.any { it.isInstance(psiElement) }
 
-        fun hasBodyIfAvailable(psiElement: PsiElement): Boolean? = DECLARATIONS_WITH_BODY_JAVA_CLASSES
-            .find { it.isInstance(psiElement) }
-            ?.let { (psiElement as KtDeclarationWithBody) }
-            ?.hasBody()
+            return isCompatibleClass && hasBodyIfAvailable(psiElement) != false
+        }
+
+        fun hasBodyIfAvailable(psiElement: PsiElement): Boolean? = when (psiElement.language) {
+            is KotlinLanguage -> DECLARATIONS_WITH_BODY_JAVA_CLASSES
+                .find { it.isInstance(psiElement) }
+                ?.let { (psiElement as KtDeclarationWithBody).hasBody() }
+
+            is JavaLanguage -> JAVA_BODY_REPLACEABLE_PSI_JAVA_CLASSES
+                .find { it.isInstance(psiElement) }
+                ?.let { (psiElement as PsiMethodImpl).body != null }
+
+            else -> null
+        }
 
         @RequiresReadLock
         fun create(
@@ -47,11 +67,12 @@ data class PsiChildrenIndexDDItem(
                     renderedType,
                 )
             } else {
+                // TODO: Update error
                 error(
                     "Invalid Psi Element. " +
-                        "Supported types: " +
-                        "KtNamedFunction, KtClassInitializer, KtPropertyAccessor, KtLambdaExpression, " +
-                        "but got ${element.javaClass.simpleName}",
+                            "Supported types: " +
+                            "KtNamedFunction, KtClassInitializer, KtPropertyAccessor, KtLambdaExpression, " +
+                            "but got ${element.javaClass.simpleName}",
                 )
             }
     }
@@ -61,12 +82,14 @@ data class PsiChildrenIndexDDItem(
         fun transform(function: KtNamedFunction): T
         fun transform(lambdaExpression: KtLambdaExpression): T
         fun transform(accessor: KtPropertyAccessor): T
+        fun transform(method: PsiMethodImpl): T
 
         fun transform(element: PsiElement): T = when (element) {
             is KtClassInitializer -> transform(element)
             is KtNamedFunction -> transform(element)
             is KtLambdaExpression -> transform(element)
             is KtPropertyAccessor -> transform(element)
+            is PsiMethodImpl -> transform(element)
             else -> error("Invalid PSI element type: ${element::class.simpleName}. Expected one of: KtClassInitializer, KtNamedFunction, KtLambdaExpression, KtPropertyAccessor")
         }
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
@@ -2,6 +2,7 @@ package org.plan.research.minimization.plugin.modification.item
 
 import org.plan.research.minimization.plugin.modification.item.index.IntChildrenIndex
 
+import com.intellij.grazie.utils.orFalse
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiParameterListOwner
@@ -52,7 +53,10 @@ data class PsiChildrenIndexDDItem(
                 else -> return false
             }.any { it.isInstance(psiElement) }
 
-            return isCompatibleClass && hasBodyIfAvailable(psiElement) != false
+            // Java constructors are not supported
+            val isConstructorCompatible = !(psiElement as? PsiMethodImpl)?.isConstructor.orFalse()
+
+            return isCompatibleClass && isConstructorCompatible && hasBodyIfAvailable(psiElement) != false
         }
 
         /**

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/item/PsiChildrenIndexDDItem.kt
@@ -2,7 +2,6 @@ package org.plan.research.minimization.plugin.modification.item
 
 import org.plan.research.minimization.plugin.modification.item.index.IntChildrenIndex
 
-import com.intellij.grazie.utils.orFalse
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiParameterListOwner
@@ -54,9 +53,9 @@ data class PsiChildrenIndexDDItem(
             }.any { it.isInstance(psiElement) }
 
             // Java constructors are not supported
-            val isConstructorCompatible = !(psiElement as? PsiMethodImpl)?.isConstructor.orFalse()
+            val isJavaConstructor = (psiElement as? PsiMethodImpl)?.isConstructor == true
 
-            return isCompatibleClass && isConstructorCompatible && hasBodyIfAvailable(psiElement) != false
+            return isCompatibleClass && !isJavaConstructor && hasBodyIfAvailable(psiElement) != false
         }
 
         /**

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
@@ -24,9 +24,9 @@ import java.nio.file.Path
  * to manage and remove unused import statements in Kotlin files.
  */
 abstract class AbstractImportRefLens<C, I, T> : BasePsiLens<C, I, T>()
-        where C : WithImportRefCounterContext<C>,
-              I : PsiDDItem<T>,
-              T : Comparable<T>, T : PsiChildrenPathIndex {
+where C : WithImportRefCounterContext<C>,
+I : PsiDDItem<T>,
+T : Comparable<T>, T : PsiChildrenPathIndex {
     private val logger = KotlinLogging.logger {}
     context(IJDDContextMonad<C>)
     override suspend fun useTrie(

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
@@ -33,7 +33,6 @@ T : Comparable<T>, T : PsiChildrenPathIndex {
         trie: PsiTrie<I, T>,
         file: PsiFile,
     ) {
-        // TODO: Is it okay to do so?
         val file = file as? KtFile ?: throw UnsupportedOperationException("Only Kotlin files are supported")
 
         // Usual PSI removing stuff

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/AbstractImportRefLens.kt
@@ -29,7 +29,7 @@ I : PsiDDItem<T>,
 T : Comparable<T>, T : PsiChildrenPathIndex {
     private val logger = KotlinLogging.logger {}
     context(IJDDContextMonad<C>)
-    override suspend fun useTrie(
+    override suspend fun focusOnTrieAndSave(
         trie: PsiTrie<I, T>,
         file: PsiFile,
     ) {
@@ -37,7 +37,7 @@ T : Comparable<T>, T : PsiChildrenPathIndex {
         val file = file as? KtFile ?: throw UnsupportedOperationException("Only Kotlin files are supported")
 
         // Usual PSI removing stuff
-        super.useTrie(trie, file)
+        super.focusOnTrieAndSave(trie, file)
 
         // Import optimization part
         val localPath = file.getLocalPath(context)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/BasePsiLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/BasePsiLens.kt
@@ -91,10 +91,9 @@ abstract class BasePsiLens<C, I, T> :
             logger.error { "The desired path for focused path $relativePath is not found in the project (name=${context.indexProject.name})" }
             return
         }
-        // TODO: Is it important to have a kt file here?
-        val psiFile = smartReadAction(context.indexProject) { PsiUtils.getPsiFile(context, virtualFile) }
+        val psiFile = smartReadAction(context.indexProject) { PsiUtils.getSourceFile(context, virtualFile) }
         psiFile ?: run {
-            logger.error { "The desired path for focused path $relativePath is not a Kotlin file in the project (name=${context.indexProject.name})" }
+            logger.error { "The desired path for focused path $relativePath is not a source file in the project (name=${context.indexProject.name})" }
             return
         }
         logger.trace { "Processing all focused elements in $relativePath" }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/BasePsiLens.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/lenses/BasePsiLens.kt
@@ -63,8 +63,14 @@ abstract class BasePsiLens<C, I, T> :
         }
     }
 
+    /**
+     * Focus on elements represented by the [PsiTrie] inside the [PsiFile].
+     *
+     * @param trie The PsiTrie containing items to be focused on.
+     * @param file The PsiFile where the changes will be performed and saved.
+     */
     context(IJDDContextMonad<C>)
-    protected open suspend fun useTrie(trie: PsiTrie<I, T>, file: PsiFile) {
+    protected open suspend fun focusOnTrieAndSave(trie: PsiTrie<I, T>, file: PsiFile) {
         PsiUtils.performPsiChangesAndSave(context, file) {
             trie.processMarkedElements(file) { item, psiElement -> focusOnPsiElement(item, psiElement, context) }
         }
@@ -92,7 +98,7 @@ abstract class BasePsiLens<C, I, T> :
             return
         }
         logger.trace { "Processing all focused elements in $relativePath" }
-        useTrie(trie, psiFile)
+        focusOnTrieAndSave(trie, psiFile)
     }
 
     protected abstract suspend fun focusOnFilesAndDirectories(itemsToDelete: List<I>, context: C)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
@@ -1,9 +1,9 @@
 package org.plan.research.minimization.plugin.modification.psi
 
-import com.intellij.psi.JavaPsiFacade
 import org.plan.research.minimization.plugin.context.IJDDContext
 import org.plan.research.minimization.plugin.modification.item.PsiChildrenIndexDDItem
 
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.PsiMethodImpl
 import mu.KotlinLogging
@@ -84,8 +84,8 @@ class PsiBodyReplacer(private val context: IJDDContext) : PsiChildrenIndexDDItem
             it.replace(
                 javaPsiFactory.createCodeBlockFromText(
                     "{\nthrow new UnsupportedOperationException(\"Removed by DD\");\n}",
-                    it.context
-                )
+                    it.context,
+                ),
             )
         }
     }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
@@ -87,7 +87,7 @@ class PsiBodyReplacer(private val context: IJDDContext) : PsiChildrenIndexDDItem
             try {
                 it.replace(block)
             } catch (e: UnsupportedOperationException) {
-                logger.error(e) { "Failed to replace body of method ${method.name}" }
+                logger.error(e) { "Failed to replace body of method ${method.name} in ${method.containingFile.virtualFile.path}" }
             }
         } ?: run {
             logger.warn { "Method ${method.name} in ${method.containingFile.virtualFile.path} has no body" }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyReplacer.kt
@@ -98,7 +98,7 @@ class PsiBodyReplacer(private val context: IJDDContext) : PsiChildrenIndexDDItem
         logger.trace { "Replacing lambda at line ${lambdaExpression.getLineNumber()} in ${lambdaExpression.containingFile.virtualFile.path}" }
         lambdaExpression.body?.let {
             // NOTE: Lambda can have an expression as a body, but `throw` is not an expression,
-            //       so code block is used as the new body in any case.
+            // so code block is used as the new body in any case.
             val block = javaPsiFactory.createCodeBlockFromText(JAVA_BLOCK_TEXT, it.context)
             try {
                 it.replace(block)

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
@@ -1,5 +1,6 @@
 package org.plan.research.minimization.plugin.modification.psi
 
+import com.intellij.psi.impl.source.PsiMethodImpl
 import org.plan.research.minimization.plugin.modification.item.PsiChildrenIndexDDItem
 import org.plan.research.minimization.plugin.modification.psi.KotlinTypeRenderer.renderType
 
@@ -30,4 +31,7 @@ object PsiBodyTypeRenderer : PsiChildrenIndexDDItem.PsiWithBodyTransformer<Strin
             val type = accessor.returnType
             renderType(accessor.containingKtFile, type)
         }
+
+    // TODO: Implement or make it unnecessary?
+    override fun transform(method: PsiMethodImpl): String? = null
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
@@ -1,9 +1,9 @@
 package org.plan.research.minimization.plugin.modification.psi
 
-import com.intellij.psi.impl.source.PsiMethodImpl
 import org.plan.research.minimization.plugin.modification.item.PsiChildrenIndexDDItem
 import org.plan.research.minimization.plugin.modification.psi.KotlinTypeRenderer.renderType
 
+import com.intellij.psi.impl.source.PsiMethodImpl
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.psi.KtClassInitializer

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiBodyTypeRenderer.kt
@@ -4,6 +4,7 @@ import org.plan.research.minimization.plugin.modification.item.PsiChildrenIndexD
 import org.plan.research.minimization.plugin.modification.psi.KotlinTypeRenderer.renderType
 
 import com.intellij.psi.impl.source.PsiMethodImpl
+import com.intellij.psi.impl.source.tree.java.PsiLambdaExpressionImpl
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.psi.KtClassInitializer
@@ -32,6 +33,7 @@ object PsiBodyTypeRenderer : PsiChildrenIndexDDItem.PsiWithBodyTransformer<Strin
             renderType(accessor.containingKtFile, type)
         }
 
-    // TODO: Implement or make it unnecessary?
+    // Rendered type is unused for java PSI
     override fun transform(method: PsiMethodImpl): String? = null
+    override fun transform(lambdaExpression: PsiLambdaExpressionImpl): String? = null
 }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiUtils.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiUtils.kt
@@ -19,18 +19,11 @@ import com.intellij.openapi.command.writeCommandAction
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiDirectory
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import com.intellij.psi.*
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.kotlin.idea.core.util.toPsiDirectory
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 
 import kotlin.io.path.relativeTo
@@ -202,6 +195,16 @@ object PsiUtils {
         PsiStubDDItem.NonOverriddenPsiStubDDItem(localPath, parentPath.map { it.bind() })
     }
 
+    /**
+     * Builds a path of parent-child relationships from a given PsiElement to
+     * the first encountered file or directory.
+     *
+     * @param element The starting PsiElement from which the path will be constructed.
+     * @param pathElementProducer A function from a parent and a child to their relationship.
+     * @param isElementAllowed A predicate of allowed PsiElement in the path.
+     * @return A pair of the topmost PsiElement in the path and the list of processed
+     *         relationships, or null if any element in the path is not allowed.
+     */
     @RequiresReadLock
     @Suppress("TYPE_ALIAS")
     private fun <T> buildParentPath(
@@ -230,7 +233,15 @@ object PsiUtils {
 
     @RequiresReadLock
     fun getKtFile(context: IJDDContext, file: VirtualFile): KtFile? =
-        PsiManagerEx.getInstance(context.indexProject).findFile(file) as? KtFile
+        getPsiFile(context, file) as? KtFile
+
+    @RequiresReadLock
+    fun getJFile(context: IJDDContext, file: VirtualFile): PsiJavaFile? =
+        getPsiFile(context, file) as? PsiJavaFile
+
+    @RequiresReadLock
+    fun getPsiFile(context: IJDDContext, file: VirtualFile): PsiFile? =
+        PsiManagerEx.getInstance(context.indexProject).findFile(file)
 
     suspend inline fun <T> performPsiChangesAndSave(
         context: IJDDContext,

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiUtils.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/PsiUtils.kt
@@ -235,6 +235,16 @@ object PsiUtils {
         getPsiFile(context, file) as? PsiJavaFile
 
     @RequiresReadLock
+    fun getSourceFile(context: IJDDContext, file: VirtualFile): PsiFile? {
+        val psiFile = getPsiFile(context, file) ?: return null
+        return when (psiFile) {
+            is PsiJavaFile -> psiFile
+            is KtFile -> psiFile
+            else -> null
+        }
+    }
+
+    @RequiresReadLock
     fun getPsiFile(context: IJDDContext, file: VirtualFile): PsiFile? =
         PsiManagerEx.getInstance(context.indexProject).findFile(file)
 

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/trie/PsiTrie.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/modification/psi/trie/PsiTrie.kt
@@ -11,10 +11,15 @@ typealias PsiProcessor<ITEM> = (ITEM, PsiElement) -> Unit
 private typealias AdjacentNodes<I, T> = MutableMap<T, PsiTrie<I, T>>
 
 /**
- * The PsiTrie class represents a trie structure designed to store and process
+ * The [PsiTrie] represents a trie structure designed to store and process
  * PSI elements associated with specific PSI elements in the root project.
+ *
+ * @param I type of element stored in the trie.
+ * @param T type of index stored in edges of the trie.
  */
-class PsiTrie<I, T> private constructor() where I : PsiDDItem<T>, T : Comparable<T>, T : PsiChildrenPathIndex {
+class PsiTrie<I, T> private constructor()
+where I : PsiDDItem<T>,
+T : Comparable<T>, T : PsiChildrenPathIndex {
     private val children: AdjacentNodes<I, T> = mutableMapOf()
     private var containingItem: I? = null
     private val logger = KotlinLogging.logger {}
@@ -48,7 +53,15 @@ class PsiTrie<I, T> private constructor() where I : PsiDDItem<T>, T : Comparable
     }
 
     companion object {
-        fun <ITEM, T> create(items: List<ITEM>): PsiTrie<ITEM, T> where ITEM : PsiDDItem<T>, T : Comparable<T>, T : PsiChildrenPathIndex {
+        /**
+         * Creates a [PsiTrie] from a list of [PsiDDItem]s.
+         *
+         * @param items list of items. `.localPath` should be the same for all.
+         * @return [PsiTrie] constructed from items.
+         */
+        fun <ITEM, T> create(items: List<ITEM>): PsiTrie<ITEM, T>
+        where ITEM : PsiDDItem<T>,
+        T : Comparable<T>, T : PsiChildrenPathIndex {
             require(items.same(PsiDDItem<T>::localPath))
             val rootNode = PsiTrie<ITEM, T>()
             items.forEach { rootNode.add(it) }

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
@@ -57,11 +57,9 @@ class MinimizationPsiManagerService {
             val javaPsi = findPsiInJavaFiles(context, PsiChildrenIndexDDItem.JAVA_BODY_REPLACEABLE_PSI_JAVA_CLASSES)
             val kotlinPsi = findPsiInKotlinFiles(context, PsiChildrenIndexDDItem.BODY_REPLACEABLE_PSI_JAVA_CLASSES)
 
-            val result = (kotlinPsi + javaPsi)
+            (kotlinPsi + javaPsi)
                 .filter { PsiChildrenIndexDDItem.isCompatible(it) }
                 .mapNotNull { PsiUtils.buildReplaceablePsiItem(context, it) }
-
-            result
         }
 
     /**

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
@@ -282,8 +282,7 @@ class MinimizationPsiManagerService {
             val fileInCurrentProject = context.projectDir.findFileByRelativePath(relativePath.pathString)
                 ?: return@flatMap emptyList()
 
-            // TODO: Is it important to check specific file type here? e.g. KtFile
-            val psiFileInCurrentProject = PsiUtils.getPsiFile(context, fileInCurrentProject)
+            val psiFileInCurrentProject = PsiUtils.getSourceFile(context, fileInCurrentProject)
                 ?: return@flatMap emptyList()
 
             classes.flatMap { clazz ->

--- a/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
+++ b/project-minimization-plugin/src/main/kotlin/org/plan/research/minimization/plugin/services/MinimizationPsiManagerService.kt
@@ -58,7 +58,7 @@ class MinimizationPsiManagerService {
             val kotlinPsi = findPsiInKotlinFiles(context, PsiChildrenIndexDDItem.BODY_REPLACEABLE_PSI_JAVA_CLASSES)
 
             val result = (kotlinPsi + javaPsi)
-                .filter { PsiChildrenIndexDDItem.hasBodyIfAvailable(it) != false }
+                .filter { PsiChildrenIndexDDItem.isCompatible(it) }
                 .mapNotNull { PsiUtils.buildReplaceablePsiItem(context, it) }
 
             result

--- a/project-minimization-plugin/src/test/kotlin/AbstractAnalysisKotlinTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/AbstractAnalysisKotlinTest.kt
@@ -1,4 +1,3 @@
-import arrow.core.compareTo
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.module.ModuleManager
@@ -6,19 +5,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.psi.PsiElement
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
-import com.intellij.util.concurrency.annotations.RequiresReadLock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.jetbrains.kotlin.idea.base.plugin.artifacts.KotlinArtifacts
-import org.plan.research.minimization.plugin.context.IJDDContext
-import org.plan.research.minimization.plugin.modification.item.index.PsiChildrenPathIndex
-import org.plan.research.minimization.plugin.modification.item.PsiDDItem
-import org.plan.research.minimization.plugin.modification.psi.PsiUtils
-import kotlin.collections.filter
 
 abstract class AbstractAnalysisKotlinTest : JavaCodeInsightFixtureTestCase() {
     override fun runInDispatchThread(): Boolean = false

--- a/project-minimization-plugin/src/test/kotlin/AbstractAnalysisKotlinTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/AbstractAnalysisKotlinTest.kt
@@ -1,3 +1,4 @@
+import arrow.core.compareTo
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.module.ModuleManager
@@ -47,26 +48,4 @@ abstract class AbstractAnalysisKotlinTest : JavaCodeInsightFixtureTestCase() {
             PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
         }
     }
-
-
-    @RequiresReadLock
-    protected fun <ITEM, T> List<ITEM>.findByPsi(
-        context: IJDDContext,
-        filter: (PsiElement) -> Boolean
-    ) where T : Comparable<T>, T : PsiChildrenPathIndex, ITEM : PsiDDItem<T> =
-        find { filter(PsiUtils.getPsiElementFromItem(context, it)!!) }
-
-    @RequiresReadLock
-    protected fun <ITEM, T> List<ITEM>.findLastByPsi(
-        context: IJDDContext,
-        filter: (PsiElement) -> Boolean
-    ) where T : Comparable<T>, T : PsiChildrenPathIndex, ITEM : PsiDDItem<T> =
-        findLast { filter(PsiUtils.getPsiElementFromItem(context, it)!!) }
-
-    @RequiresReadLock
-    protected fun <ITEM, T> List<ITEM>.filterByPsi(
-        context: IJDDContext,
-        filter: (PsiElement) -> Boolean
-    ) where T : Comparable<T>, T : PsiChildrenPathIndex, ITEM : PsiDDItem<T> =
-        filter { filter(PsiUtils.getPsiElementFromItem(context, it)!!) }
 }

--- a/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/DeclarationDeletingLensTest.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findFile
 import com.intellij.testFramework.PlatformTestUtil
+import filterByPsi
+import findByPsi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -43,8 +45,7 @@ class TestContext(
     override val callTraceParameterCache: CallTraceParameterCache
 ) : LightIJDDContext<TestContext>(projectDir, indexProject, originalProject),
     WithImportRefCounterContext<TestContext>,
-    WithCallTraceParameterCacheContext<TestContext>
-{
+    WithCallTraceParameterCacheContext<TestContext> {
 
     constructor(
         project: Project,
@@ -79,7 +80,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val importRefCounter = runBlocking {
             KtSourceImportRefCounter.create(HeavyTestContext(project)).getOrNull()
         }
-        val cache = runBlocking { 
+        val cache = runBlocking {
             val defaultContext = DefaultProjectContext(project)
             val allCallableItems = service<MinimizationPsiManagerService>()
                 .buildDeletablePsiGraph(defaultContext, true)
@@ -277,19 +278,21 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
             doTest(test1, itemsStage2, "project-secondary-constructor-simple-stage-2")
         }
     }
+
     fun testSecondaryConstructorParameter() {
         myFixture.copyDirectoryToProject("project-secondary-constructor-parameter-simple", ".")
         val context = createContext()
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "y"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "y" }.single()
             }
         }
         runBlocking {
             doTest(context, listOf(item), "project-secondary-constructor-parameter-simple-result")
         }
     }
+
     fun testSecondaryConstructorParameterLinked() {
         myFixture.copyDirectoryToProject("project-secondary-constructor-parameter-simple", ".")
         configureModules(project)
@@ -298,13 +301,14 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "x"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "x" }.single()
             }
         }
         runBlocking {
             doTest(context, listOf(item), "project-secondary-constructor-parameter-complicated-result")
         }
     }
+
     fun testDefaultFunctionParametersX() {
         myFixture.copyDirectoryToProject("project-default-function-parameters", ".")
         configureModules(project)
@@ -313,13 +317,14 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "x"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "x" }.single()
             }
         }
         runBlocking {
             doTest(context, listOf(item), "project-default-function-parameters-result-x")
         }
     }
+
     fun testDefaultFunctionParametersY() {
         myFixture.copyDirectoryToProject("project-default-function-parameters", ".")
         configureModules(project)
@@ -328,13 +333,14 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "y"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "y" }.single()
             }
         }
         runBlocking {
             doTest(context, listOf(item), "project-default-function-parameters-result-y")
         }
     }
+
     fun testDefaultFunctionParametersLambda() {
         myFixture.copyDirectoryToProject("project-default-function-parameters", ".")
         configureModules(project)
@@ -343,7 +349,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "lambda"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "lambda" }.single()
             }
         }
         runBlocking {
@@ -359,13 +365,14 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "y"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "y" }.single()
             }
         }
         runBlocking {
             doTest(context, listOf(item), "project-named-function-parameters-result")
         }
     }
+
     fun testNamedFunctionParametersMultiStage() {
         return
         myFixture.copyDirectoryToProject("project-named-function-parameters", ".")
@@ -375,7 +382,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         val allItems = runBlocking { getAllItems(context) }
         val item = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "y"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "y" }.single()
             }
         }
         val contextAfterStage1 = runBlocking {
@@ -383,7 +390,7 @@ class DeclarationDeletingLensTest : PsiLensTestBase<TestContext, PsiStubDDItem, 
         }
         val itemStage2 = runBlocking {
             readAction {
-                allItems.filterByPsi(context) { it is KtParameter && it.name == "x"}.single()
+                allItems.filterByPsi(context) { it is KtParameter && it.name == "x" }.single()
             }
         }
         runBlocking {

--- a/project-minimization-plugin/src/test/kotlin/lens/FunctionModificationLensTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/FunctionModificationLensTest.kt
@@ -95,6 +95,16 @@ class FunctionModificationLensTest : PsiLensTestBase<LightTestContext, PsiChildr
         }
     }
 
+    fun testProjectJava() {
+        myFixture.copyDirectoryToProject("project-java-included", ".")
+        configureModules(project)
+        val context = LightTestContext(project)
+        runBlocking {
+            val elements = getAllItems(context)
+            doTest(context, elements, "project-java-included-modified")
+        }
+    }
+
     override suspend fun doTest(
         initialContext: LightTestContext,
         elements: List<PsiChildrenIndexDDItem>,

--- a/project-minimization-plugin/src/test/kotlin/lens/FunctionModificationLensTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/lens/FunctionModificationLensTest.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findFile
 import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.psi.PsiElement
+import filterByPsi
+import findByPsi
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.psi.KtLambdaExpression
@@ -106,7 +108,12 @@ class FunctionModificationLensTest : PsiLensTestBase<LightTestContext, PsiChildr
         return cloned.runMonad {
             lens.focusOn(elements)
 
-            val files = buildList { VfsUtil.iterateChildrenRecursively(context.projectDir, null) { fileOrDir -> add(fileOrDir) } }
+            val files = buildList {
+                VfsUtil.iterateChildrenRecursively(
+                    context.projectDir,
+                    null
+                ) { fileOrDir -> add(fileOrDir) }
+            }
             val projectRoot = context.projectDir.toNioPath()
 
             files.mapNotNull { smartReadAction(context.indexProject) { it.toPsiFile(context.indexProject) } }

--- a/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/graph/InstanceLevelGraphCollectionTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.PlatformTestUtil
+import filterByPsi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -184,10 +185,9 @@ class InstanceLevelGraphCollectionTest : AbstractAnalysisKotlinTest() {
     private suspend inline fun <reified T : PsiElement> InstanceLevelGraph.findByClassAndName(
         context: IJDDContext,
         name: String?
-    ) =
-        readAction {
-            vertexSet().toList().filterByPsi(context) { it is T && (name == null || it.name == name) }
-        }
+    ) = readAction {
+        vertexSet().toList().filterByPsi(context) { it is T && (name == null || it.name == name) }
+    }
 
     private val PsiElement.name: String
         get() = when (this) {

--- a/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerDeletablePsiTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerDeletablePsiTest.kt
@@ -3,6 +3,7 @@ package psi.manager
 import LightTestContext
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.service
+import getPsi
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.hasBody
@@ -70,6 +71,7 @@ class MinimizationPsiManagerDeletablePsiTest : MinimizationPsiManagerTestBase() 
             }
         }
     }
+
     fun testClassClass() {
         val service = service<MinimizationPsiManagerService>()
         val context = LightTestContext(project)

--- a/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingJavaTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingJavaTest.kt
@@ -1,0 +1,47 @@
+package psi.manager
+
+import LightTestContext
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.components.service
+import com.intellij.psi.PsiCodeBlock
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.impl.source.PsiMethodImpl
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase
+import getPsi
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.kotlin.psi.*
+import org.plan.research.minimization.plugin.modification.psi.PsiUtils
+import org.plan.research.minimization.plugin.services.MinimizationPsiManagerService
+import kotlin.test.assertIs
+
+class MinimizationPsiManagerGettingJavaTest : JavaCodeInsightFixtureTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/resources/testData/java-psi"
+    }
+
+    override fun runInDispatchThread(): Boolean = false
+
+    fun testSimpleClass() {
+        val service = service<MinimizationPsiManagerService>()
+        val psiFile = myFixture.configureByFile("simple-class.java")
+        assertIs<PsiJavaFile>(psiFile)
+        val context = LightTestContext(project)
+        val ddItems = runBlocking {
+            service.findAllPsiWithBodyItems(context)
+        }
+
+        runBlocking {
+            readAction {
+                val psiElements = ddItems.getPsi(context)
+                assertSize(3, psiElements)
+
+                psiElements.forEachIndexed { idx, it ->
+                    assertIs<PsiMethodImpl>(it)
+                    assertEquals("method${idx + 1}", it.name)
+                    assertNotNull(it.body)
+                    assertIs<PsiCodeBlock>(it.body)
+                }
+            }
+        }
+    }
+}

--- a/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.*
 import org.plan.research.minimization.plugin.modification.psi.PsiUtils
 import org.plan.research.minimization.plugin.services.MinimizationPsiManagerService
 import kotlin.test.assertIs
+import getPsi
 
 class MinimizationPsiManagerGettingTest : MinimizationPsiManagerTestBase() {
     override fun getTestDataPath(): String {
@@ -15,7 +16,7 @@ class MinimizationPsiManagerGettingTest : MinimizationPsiManagerTestBase() {
     }
 
     override fun runInDispatchThread(): Boolean = false
-    
+
     fun testFunctions() {
         val service = service<MinimizationPsiManagerService>()
         val psiFile = myFixture.configureByFile("functions.kt")

--- a/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingTest.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingTest.kt
@@ -15,6 +15,7 @@ class MinimizationPsiManagerGettingTest : MinimizationPsiManagerTestBase() {
     }
 
     override fun runInDispatchThread(): Boolean = false
+    
     fun testFunctions() {
         val service = service<MinimizationPsiManagerService>()
         val psiFile = myFixture.configureByFile("functions.kt")

--- a/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerTestBase.kt
+++ b/project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerTestBase.kt
@@ -13,8 +13,4 @@ abstract class MinimizationPsiManagerTestBase : AbstractAnalysisKotlinTest() {
     }
 
     override fun runInDispatchThread(): Boolean = false
-
-    protected fun <T> List<PsiDDItem<T>>.getPsi(context: IJDDContext) where T : PsiChildrenPathIndex, T : Comparable<T> =
-        sortedWith { a, b -> a.childrenPath.compareTo(b.childrenPath) }
-            .map { PsiUtils.getPsiElementFromItem(context, it) }
 }

--- a/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included-modified/j.java
+++ b/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included-modified/j.java
@@ -1,0 +1,9 @@
+class SimpleClass {
+    public String method() {
+        throw new UnsupportedOperationException("Removed by DD");
+    }
+
+    public String field = "test".transform(s -> {
+        throw new UnsupportedOperationException("Removed by DD");
+    })
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included-modified/k.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included-modified/k.kt
@@ -1,0 +1,1 @@
+fun function() = TODO("Removed by DD") as Int

--- a/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included/j.java
+++ b/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included/j.java
@@ -1,0 +1,7 @@
+class SimpleClass {
+    public String method() {
+        return "test";
+    }
+
+    public String field = "test".transform(s -> s + "passed")
+}

--- a/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included/k.kt
+++ b/project-minimization-plugin/src/test/resources/testData/function-modification/project-java-included/k.kt
@@ -1,0 +1,1 @@
+fun function() = 42

--- a/project-minimization-plugin/src/test/resources/testData/java-psi/class-class.java
+++ b/project-minimization-plugin/src/test/resources/testData/java-psi/class-class.java
@@ -1,0 +1,26 @@
+class SimpleClass {
+    class InnerClass1 {
+        public void method1() {
+            System.out.println("first method");
+        }
+    }
+
+    public void method2() {
+        class InnerClass2 {
+            // Inside a method -> not collected
+            public void uncollected() {
+                System.out.println("uncollected");
+            }
+        }
+
+        InnerClass2 inner = new InnerClass2();
+        inner.uncollected();
+    }
+
+    public boolean field = Stream.of("test").allMatch(new Predicate<String>() {
+        // collected
+        public boolean test(String s) {
+            return false;
+        }
+    })
+}

--- a/project-minimization-plugin/src/test/resources/testData/java-psi/lambdas.java
+++ b/project-minimization-plugin/src/test/resources/testData/java-psi/lambdas.java
@@ -1,0 +1,12 @@
+class TestClass {
+    public Runnable r1 = () -> System.out.println("Expression");
+    public Runnable r2 = () -> {
+        System.out.println("Block");
+    };
+    public String str = Stream.of("test")
+        .filter(s -> s.length() > 0)
+        .filter(s -> {
+            return s.length() < 42
+        }).findFirst().orElse("empty");
+}
+

--- a/project-minimization-plugin/src/test/resources/testData/java-psi/simple-class.java
+++ b/project-minimization-plugin/src/test/resources/testData/java-psi/simple-class.java
@@ -1,0 +1,18 @@
+class SimpleClass {
+    // Constructor -> not collected
+    public SimpleClass() {}
+
+    private String method1() {
+        return "test";
+    }
+
+    public void method2() {
+    }
+
+    static int method3() {
+        return 42;
+    }
+
+    // No body -> not collected
+    protected int uncollectedMethod()
+}


### PR DESCRIPTION
## JBRes-???? Support Java methods and lambda expressions modification in function modification stage

## Description

Support body replacement with `throw new UnsupportedOperationException("Removed by DD");` for Java methods and lambda expressions. For this, PSI collection was updated to include Java source files and `PsiBodyReplacer` was updated to support corresponding Java PSI elements.

## How to test

### Automated tests

`project-minimization-plugin/src/test/kotlin/psi/manager/MinimizationPsiManagerGettingJavaTest.kt` and `project-minimization-plugin/src/test/kotlin/lens/FunctionModificationLensTest.kt`

## Self-check list

- [x] PR **title** and **description** are clear and aligned with a format.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas. 
- [x] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided _optionally_.
- [x] The **documentation** for the functionality I've been working on is up-to-date/provided.
- [ ] The **link** to this PR is commented on in the corresponding **YT ticket**.

Hint: [x] is a marked item
